### PR TITLE
add elm-css and enable addition of styling to body

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,11 +11,14 @@
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
             "elm/url": "1.0.0",
-            "hmsk/elm-vite-plugin-helper": "1.0.1"
+            "hmsk/elm-vite-plugin-helper": "1.0.1",
+            "rtfeldman/elm-css": "18.0.0"
         },
         "indirect": {
             "elm/time": "1.0.0",
-            "elm/virtual-dom": "1.0.3"
+            "elm/virtual-dom": "1.0.3",
+            "robinheghan/murmur3": "1.0.0",
+            "rtfeldman/elm-hex": "1.0.0"
         }
     },
     "test-dependencies": {

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,8 +1,7 @@
 module Main exposing (main)
 
 import Browser
-import Html exposing (Html, h1, text)
-
+import Html.Styled as Html exposing (..)
 
 type alias Flags =
     ()
@@ -49,7 +48,7 @@ subscriptions model =
 
 viewDocument : Model -> Browser.Document Msg
 viewDocument model =
-    { title = "[cCc] App title", body = [ view model ] }
+    { title = "[cCc] App title", body = [toUnstyled (view model) ] }
 
 
 view : Model -> Html Msg


### PR DESCRIPTION
Fixes #5 

## Description

- Adds elm-css
- I had to use this `toUnstyled` function in order to successfully apply styling  - without this Browser.Document doesn't recognise the body as the correct type. We may not need this here in the end, but leaving in for now as guidance to avoid this bug on other pages

@geeksforsocialchange/developers
