### PR TITLE
Add theme and page stubs

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -50,33 +50,9 @@ subscriptions model =
 
 viewDocument : Model -> Browser.Document Msg
 viewDocument model =
-    { title = "[cCc] App title", body = List.map (\item -> toUnstyled item) (view model) }
+    { title = "[cCc] App title", body = [ toUnstyled (view model) ] }
 
 
-view : Model -> List (Html Msg)
+view : Model -> Html Msg
 view model =
-    PageTemplate.view { headerContent = headerView, mainContent = mainView, footerContent = footerView }
-
-
-mainView : Html Msg
-mainView =
-    p
-        []
-        [ text "[cCc] Main template"
-        ]
-
-
-footerView : Html Msg
-footerView =
-    h2
-        []
-        [ text "[cCc] Footer"
-        ]
-
-
-headerView : Html Msg
-headerView =
-    h1
-        []
-        [ text "[cCc] Header"
-        ]
+    PageTemplate.view { title = "[cCc] Header", mainContent = "[cCc] Content" }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -50,12 +50,33 @@ subscriptions model =
 
 viewDocument : Model -> Browser.Document Msg
 viewDocument model =
-    { title = "[cCc] App title", body = [ toUnstyled (PageTemplate.view { content = view model }) ] }
+    { title = "[cCc] App title", body = List.map (\item -> toUnstyled item) (view model) }
 
 
-view : Model -> Html Msg
+view : Model -> List (Html Msg)
 view model =
+    PageTemplate.view { headerContent = headerView, mainContent = mainView, footerContent = footerView }
+
+
+mainView : Html Msg
+mainView =
+    p
+        []
+        [ text "[cCc] Main template"
+        ]
+
+
+footerView : Html Msg
+footerView =
+    h2
+        []
+        [ text "[cCc] Footer"
+        ]
+
+
+headerView : Html Msg
+headerView =
     h1
         []
-        [ text "[cCc] Init template"
+        [ text "[cCc] Header"
         ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -4,6 +4,7 @@ import Browser
 import Html.Styled as Html exposing (..)
 import Theme.PageTemplate as PageTemplate
 
+
 type alias Flags =
     ()
 
@@ -49,7 +50,7 @@ subscriptions model =
 
 viewDocument : Model -> Browser.Document Msg
 viewDocument model =
-    { title = "[cCc] App title", body = [toUnstyled (PageTemplate.view { content = Just(view model) }) ] }
+    { title = "[cCc] App title", body = [ toUnstyled (PageTemplate.view { content = view model }) ] }
 
 
 view : Model -> Html Msg

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -2,6 +2,7 @@ module Main exposing (main)
 
 import Browser
 import Html.Styled as Html exposing (..)
+import Theme.PageTemplate as PageTemplate
 
 type alias Flags =
     ()
@@ -48,7 +49,7 @@ subscriptions model =
 
 viewDocument : Model -> Browser.Document Msg
 viewDocument model =
-    { title = "[cCc] App title", body = [toUnstyled (view model) ] }
+    { title = "[cCc] App title", body = [toUnstyled (PageTemplate.view { content = Just(view model) }) ] }
 
 
 view : Model -> Html Msg

--- a/src/Theme/FooterTemplate.elm
+++ b/src/Theme/FooterTemplate.elm
@@ -1,17 +1,18 @@
 module Theme.FooterTemplate exposing (..)
 
 import Css exposing (Style, batch)
-import Html.Styled as Html exposing (Html, footer)
+import Html.Styled exposing (Html, footer, h2, text)
 import Html.Styled.Attributes exposing (css)
 
 
-type alias PageUsingTemplate msg =
-    { content : Html msg }
-
-
-view : PageUsingTemplate msg -> Html.Html msg
-view footerInfo =
-    footer [ css [ footerStyle ] ] [ footerInfo.content ]
+view : Html msg
+view =
+    footer [ css [ footerStyle ] ]
+        [ h2
+            []
+            [ text "[cCc] Footer"
+            ]
+        ]
 
 
 footerStyle : Style

--- a/src/Theme/FooterTemplate.elm
+++ b/src/Theme/FooterTemplate.elm
@@ -1,0 +1,20 @@
+module Theme.FooterTemplate exposing (..)
+
+import Css exposing (Style, batch)
+import Html.Styled as Html exposing (Html, footer)
+import Html.Styled.Attributes exposing (css)
+
+
+type alias PageUsingTemplate msg =
+    { content : Html msg }
+
+
+view : PageUsingTemplate msg -> Html.Html msg
+view footerInfo =
+    footer [ css [ footerStyle ] ] [ footerInfo.content ]
+
+
+footerStyle : Style
+footerStyle =
+    batch
+        []

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,11 +1,14 @@
 module Theme.Global exposing (..)
 
-import Css exposing (Style, absolute, auto, batch, height, hidden, left, overflow,position, px, top, width)
+import Css exposing (Style, absolute, auto, batch, height, hidden, left, overflow, position, px, top, width)
 import Css.Global exposing (global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html)
 
+
+
 -- Accessibility helpers
+
 
 screenReaderOnly : Style
 screenReaderOnly =
@@ -18,7 +21,11 @@ screenReaderOnly =
         , overflow hidden
         ]
 
+
+
 -- Breakpoints
+
+
 maxMobile : Float
 maxMobile =
     600
@@ -64,29 +71,20 @@ withMediaMediumDesktopUp =
     withMedia [ only screen [ Media.minWidth (px maxSmallDesktop) ] ]
 
 
+
 -- Brand colours
-
 -- Accent colours
-
 -- Text and background colours
-
 -- Transitions
-
 -- Buttons (components)
-
 -- Buttons (styles)
-
 -- Titles
-
 -- Page Elements
-
 -- Text styles
-
 -- Form field components
-
 -- Form field styles
-
 -- Global
+
 
 {-| Injects a <style> tag into the body, and can target element or
 class selectors anywhere, including outside the Elm app.
@@ -95,24 +93,24 @@ globalStyles : Html msg
 globalStyles =
     global
         [ typeSelector "body"
-            [ ]
+            []
         , typeSelector "h1"
-            [ ]
+            []
         , typeSelector "h2"
-            [ ]
+            []
         , typeSelector "h3"
-            [ ]
+            []
         , typeSelector "h4"
-            [ ]
+            []
         , typeSelector "b"
-            [ ]
+            []
         , typeSelector "p"
-            [ ]
+            []
         , typeSelector "blockquote"
             []
         ]
 
+
+
 -- Helpers
-
 -- Map
-

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,0 +1,118 @@
+module Theme.Global exposing (..)
+
+import Css exposing (Style, absolute, auto, batch, height, hidden, left, overflow,position, px, top, width)
+import Css.Global exposing (global, typeSelector)
+import Css.Media as Media exposing (only, screen, withMedia)
+import Html.Styled exposing (Html)
+
+-- Accessibility helpers
+
+screenReaderOnly : Style
+screenReaderOnly =
+    batch
+        [ position absolute
+        , left (px -10000)
+        , top auto
+        , width (px 1)
+        , height (px 1)
+        , overflow hidden
+        ]
+
+-- Breakpoints
+maxMobile : Float
+maxMobile =
+    600
+
+
+withMediaMobileOnly : List Style -> Style
+withMediaMobileOnly =
+    withMedia [ only screen [ Media.maxWidth (px (maxMobile - 1)) ] ]
+
+
+withMediaTabletPortraitUp : List Style -> Style
+withMediaTabletPortraitUp =
+    withMedia [ only screen [ Media.minWidth (px maxMobile) ] ]
+
+
+maxTabletPortrait : Float
+maxTabletPortrait =
+    900
+
+
+withMediaTabletLandscapeUp : List Style -> Style
+withMediaTabletLandscapeUp =
+    withMedia [ only screen [ Media.minWidth (px maxTabletPortrait) ] ]
+
+
+maxTabletLandscape : Float
+maxTabletLandscape =
+    1200
+
+
+withMediaSmallDesktopUp : List Style -> Style
+withMediaSmallDesktopUp =
+    withMedia [ only screen [ Media.minWidth (px maxTabletLandscape) ] ]
+
+
+maxSmallDesktop : Float
+maxSmallDesktop =
+    1500
+
+
+withMediaMediumDesktopUp : List Style -> Style
+withMediaMediumDesktopUp =
+    withMedia [ only screen [ Media.minWidth (px maxSmallDesktop) ] ]
+
+
+-- Brand colours
+
+-- Accent colours
+
+-- Text and background colours
+
+-- Transitions
+
+-- Buttons (components)
+
+-- Buttons (styles)
+
+-- Titles
+
+-- Page Elements
+
+-- Text styles
+
+-- Form field components
+
+-- Form field styles
+
+-- Global
+
+{-| Injects a <style> tag into the body, and can target element or
+class selectors anywhere, including outside the Elm app.
+-}
+globalStyles : Html msg
+globalStyles =
+    global
+        [ typeSelector "body"
+            [ ]
+        , typeSelector "h1"
+            [ ]
+        , typeSelector "h2"
+            [ ]
+        , typeSelector "h3"
+            [ ]
+        , typeSelector "h4"
+            [ ]
+        , typeSelector "b"
+            [ ]
+        , typeSelector "p"
+            [ ]
+        , typeSelector "blockquote"
+            []
+        ]
+
+-- Helpers
+
+-- Map
+

--- a/src/Theme/HeaderTemplate.elm
+++ b/src/Theme/HeaderTemplate.elm
@@ -1,0 +1,20 @@
+module Theme.HeaderTemplate exposing (..)
+
+import Css exposing (Style, batch)
+import Html.Styled as Html exposing (Html, header)
+import Html.Styled.Attributes exposing (css)
+
+
+type alias PageUsingTemplate msg =
+    { content : Html msg }
+
+
+view : PageUsingTemplate msg -> Html.Html msg
+view headerInfo =
+    header [ css [ headerStyle ] ] [ headerInfo.content ]
+
+
+headerStyle : Style
+headerStyle =
+    batch
+        []

--- a/src/Theme/HeaderTemplate.elm
+++ b/src/Theme/HeaderTemplate.elm
@@ -1,17 +1,22 @@
 module Theme.HeaderTemplate exposing (..)
 
 import Css exposing (Style, batch)
-import Html.Styled as Html exposing (Html, header)
+import Html.Styled exposing (Html, h1, header, text)
 import Html.Styled.Attributes exposing (css)
 
 
-type alias PageUsingTemplate msg =
-    { content : Html msg }
+type alias HeaderInfo =
+    { content : String }
 
 
-view : PageUsingTemplate msg -> Html.Html msg
+view : HeaderInfo -> Html msg
 view headerInfo =
-    header [ css [ headerStyle ] ] [ headerInfo.content ]
+    header [ css [ headerStyle ] ]
+        [ h1
+            []
+            [ text headerInfo.content
+            ]
+        ]
 
 
 headerStyle : Style

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -1,7 +1,6 @@
 module Theme.PageTemplate exposing (..)
 
 import Css exposing (Style, batch)
-
 import Html.Styled as Html exposing (div, text)
 import Html.Styled.Attributes exposing (css)
 
@@ -14,13 +13,13 @@ type alias PageUsingTemplate msg =
 
 view : PageUsingTemplate msg -> Html.Html msg
 view pageInfo =
-    div []
-        [ case pageInfo.content of
+    div [][ 
+        case pageInfo.content of
             Just pageContents ->
                 div [ css [ mainStyle ] ] [ pageContents ]
             Nothing ->
-                text "" ]
-        
+                text "" 
+        ]
 
 mainStyle : Style
 mainStyle =

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -1,0 +1,29 @@
+module Theme.PageTemplate exposing (..)
+
+import Css exposing (Style, batch)
+
+import Html.Styled as Html exposing (div, text)
+import Html.Styled.Attributes exposing (css)
+
+
+type alias Msg =
+    Never
+
+type alias PageUsingTemplate msg =
+    { content : Maybe (Html.Html msg) }
+
+view : PageUsingTemplate msg -> Html.Html msg
+view pageInfo =
+    div []
+        [ case pageInfo.content of
+            Just pageContents ->
+                div [ css [ mainStyle ] ] [ pageContents ]
+            Nothing ->
+                text "" ]
+        
+
+mainStyle : Style
+mainStyle =
+    batch
+        [
+        ]

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -1,25 +1,37 @@
 module Theme.PageTemplate exposing (..)
 
 import Css exposing (Style, batch)
-import Html.Styled as Html exposing (Html, main_)
+import Html.Styled exposing (Html, div, main_, p, text)
 import Html.Styled.Attributes exposing (css)
 import Theme.FooterTemplate as FooterTemplate
 import Theme.HeaderTemplate as HeaderTemplate
 
 
-type alias PageUsingTemplate msg =
-    { headerContent : Html msg, mainContent : Html msg, footerContent : Html msg }
+type alias PageInfo =
+    { title : String, mainContent : String }
 
 
-view : PageUsingTemplate msg -> List (Html.Html msg)
+view : PageInfo -> Html msg
 view pageInfo =
-    [ HeaderTemplate.view { content = pageInfo.headerContent }
-    , main_ [ css [ mainStyle ] ] [ pageInfo.mainContent ]
-    , FooterTemplate.view { content = pageInfo.footerContent }
-    ]
+    div [ css [ defaultPageStyle ] ]
+        [ HeaderTemplate.view { content = pageInfo.title }
+        , main_ [ css [ mainStyle ] ]
+            [ p
+                []
+                [ text pageInfo.mainContent
+                ]
+            ]
+        , FooterTemplate.view
+        ]
 
 
 mainStyle : Style
 mainStyle =
+    batch
+        []
+
+
+defaultPageStyle : Style
+defaultPageStyle =
     batch
         []

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -1,16 +1,22 @@
 module Theme.PageTemplate exposing (..)
 
 import Css exposing (Style, batch)
-import Html.Styled as Html exposing (Html, div)
+import Html.Styled as Html exposing (Html, main_)
 import Html.Styled.Attributes exposing (css)
+import Theme.FooterTemplate as FooterTemplate
+import Theme.HeaderTemplate as HeaderTemplate
+
 
 type alias PageUsingTemplate msg =
-    { content : Html msg }
+    { headerContent : Html msg, mainContent : Html msg, footerContent : Html msg }
 
 
-view : PageUsingTemplate msg -> Html.Html msg
+view : PageUsingTemplate msg -> List (Html.Html msg)
 view pageInfo =
-    div [ css [ mainStyle ] ] [ pageInfo.content ]
+    [ HeaderTemplate.view { content = pageInfo.headerContent }
+    , main_ [ css [ mainStyle ] ] [ pageInfo.mainContent ]
+    , FooterTemplate.view { content = pageInfo.footerContent }
+    ]
 
 
 mainStyle : Style

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -1,28 +1,19 @@
 module Theme.PageTemplate exposing (..)
 
 import Css exposing (Style, batch)
-import Html.Styled as Html exposing (div, text)
+import Html.Styled as Html exposing (Html, div)
 import Html.Styled.Attributes exposing (css)
 
-
-type alias Msg =
-    Never
-
 type alias PageUsingTemplate msg =
-    { content : Maybe (Html.Html msg) }
+    { content : Html msg }
+
 
 view : PageUsingTemplate msg -> Html.Html msg
 view pageInfo =
-    div [][ 
-        case pageInfo.content of
-            Just pageContents ->
-                div [ css [ mainStyle ] ] [ pageContents ]
-            Nothing ->
-                text "" 
-        ]
+    div [ css [ mainStyle ] ] [ pageInfo.content ]
+
 
 mainStyle : Style
 mainStyle =
     batch
-        [
-        ]
+        []


### PR DESCRIPTION
Fixes #12

## Description

- Adds a theme file with some boilerplate code - headers for categorising different types of styling, global styles, media queries & screen reader only text
- Adds a basic page template within themes folder and uses this for the home page

@geeksforsocialchange/developers
