### PR TITLE
fix bad elm.json

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,7 @@
 # elm-package generated files
 elm-stuff
+elm.json
+elm-tooling.json
 
 # elm-repl generated files
 repl-temp-*
@@ -11,3 +13,4 @@ package-lock.json
 
 # build files
 dist
+

--- a/elm-tooling.json
+++ b/elm-tooling.json
@@ -1,7 +1,7 @@
 {
-  "tools": {
-    "elm": "0.19.1",
-    "elm-format": "0.8.6",
-    "elm-json": "0.2.13"
-  }
+    "tools": {
+        "elm": "0.19.1",
+        "elm-format": "0.8.6",
+        "elm-json": "0.2.13"
+    }
 }

--- a/elm.json
+++ b/elm.json
@@ -1,41 +1,38 @@
 {
-  "type": "application",
-  "source-directories": ["src"],
-  "elm-version": "0.19.1",
-  "dependencies": {
-    "direct": {
-      "elm/browser": "1.0.2",
-      "elm/core": "1.0.5",
-      "elm/html": "1.0.0",
-      "elm/json": "1.1.3",
-      "elm/url": "1.0.0",
-      "hmsk/elm-vite-plugin-helper": "1.0.1",
-      "jfmengels/elm-review": "2.12.2",
-      "rtfeldman/elm-css": "18.0.0"
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0",
+            "elm/json": "1.1.3",
+            "elm/url": "1.0.0",
+            "elm-explorations/test": "2.1.1",
+            "hmsk/elm-vite-plugin-helper": "1.0.1",
+            "jfmengels/elm-review": "2.12.2",
+            "rtfeldman/elm-css": "18.0.0"
+        },
+        "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/parser": "1.1.0",
+            "elm/project-metadata-utils": "1.0.2",
+            "elm/random": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/virtual-dom": "1.0.3",
+            "elm-community/list-extra": "8.7.0",
+            "miniBill/elm-unicode": "1.0.3",
+            "robinheghan/murmur3": "1.0.0",
+            "rtfeldman/elm-hex": "1.0.0",
+            "stil4m/elm-syntax": "7.2.9",
+            "stil4m/structured-writer": "1.0.3"
+        }
     },
-    "indirect": {
-      "elm/bytes": "1.0.8",
-      "elm/parser": "1.1.0",
-      "elm/project-metadata-utils": "1.0.2",
-      "elm/random": "1.0.0",
-      "elm/time": "1.0.0",
-      "elm/virtual-dom": "1.0.3",
-      "elm-community/list-extra": "8.7.0",
-      "elm-explorations/test": "2.1.1",
-      "miniBill/elm-unicode": "1.0.3",
-      "robinheghan/murmur3": "1.0.0",
-      "rtfeldman/elm-hex": "1.0.0",
-      "stil4m/elm-syntax": "7.2.9",
-      "stil4m/structured-writer": "1.0.3"
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
     }
-  },
-  "test-dependencies": {
-    "direct": {
-      "elm-explorations/test": "2.1.1"
-    },
-    "indirect": {
-      "elm/bytes": "1.0.8",
-      "elm/random": "1.0.0"
-    }
-  }
 }


### PR DESCRIPTION
Fixes broken build

## Description

- add `elm.json` & `elm-tooling.json` back to `.prettierignore`
- replace `elm.json` & `elm-tooling.json` with version formatted by the elm cli tools

@geeksforsocialchange/developers
