### PR TITLE
59 rename resource and case study

### DIFF
--- a/src/I18n/Cy.elm
+++ b/src/I18n/Cy.elm
@@ -10,7 +10,7 @@ cyStrings key =
             "[cCc] Team Wilder CY"
 
         StoryTitle ->
-            "[cCc] Case Study CY"
+            "[cCc] Story CY"
 
         ResourceTitle ->
             "[cCc] Resource CY"

--- a/src/I18n/Cy.elm
+++ b/src/I18n/Cy.elm
@@ -9,7 +9,7 @@ cyStrings key =
         SiteTitle ->
             "[cCc] Team Wilder CY"
 
-        CaseStudyTitle ->
+        StoryTitle ->
             "[cCc] Case Study CY"
 
         ResourceTitle ->

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -12,7 +12,7 @@ enStrings key =
         SiteTitle ->
             "[cCc] Team Wilder"
 
-        CaseStudyTitle ->
+        StoryTitle ->
             "[cCc] Case Study"
 
         ResourceTitle ->

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -13,7 +13,7 @@ enStrings key =
             "[cCc] Team Wilder"
 
         StoryTitle ->
-            "[cCc] Case Study"
+            "[cCc] Story"
 
         ResourceTitle ->
             "[cCc] Resource"

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -4,7 +4,7 @@ module I18n.Keys exposing (Key(..))
 type Key
     = SiteTitle
       --- Page Titles
-    | CaseStudyTitle
+    | StoryTitle
     | ResourceTitle
     | ChangeLanguage
       --- 404 content

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -100,11 +100,11 @@ view model =
 
         StoryIndex ->
             Theme.PageTemplate.view model
-                { title = CaseStudyTitle, content = Page.Story.view model }
+                { title = StoryTitle, content = Page.Story.view model }
 
         Story _ ->
             Theme.PageTemplate.view model
-                { title = CaseStudyTitle, content = Page.Story.view model }
+                { title = StoryTitle, content = Page.Story.view model }
 
         Resource slug ->
             Theme.PageTemplate.view model

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -98,11 +98,11 @@ view model =
             Theme.PageTemplate.view model
                 { title = SiteTitle, content = Page.Index.view model }
 
-        CaseStudyIndex ->
+        StoryIndex ->
             Theme.PageTemplate.view model
                 { title = CaseStudyTitle, content = Page.Story.view model }
 
-        CaseStudy _ ->
+        Story _ ->
             Theme.PageTemplate.view model
                 { title = CaseStudyTitle, content = Page.Story.view model }
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -5,10 +5,10 @@ import Browser.Navigation
 import Html.Styled exposing (Html, toUnstyled)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..))
-import Page.CaseStudy
 import Page.Index
 import Page.Resource.Data
 import Page.Resource.View
+import Page.Story
 import Route exposing (Route(..))
 import Shared exposing (Model, Msg(..))
 import Theme.PageTemplate
@@ -100,11 +100,11 @@ view model =
 
         CaseStudyIndex ->
             Theme.PageTemplate.view model
-                { title = CaseStudyTitle, content = Page.CaseStudy.view model }
+                { title = CaseStudyTitle, content = Page.Story.view model }
 
         CaseStudy _ ->
             Theme.PageTemplate.view model
-                { title = CaseStudyTitle, content = Page.CaseStudy.view model }
+                { title = CaseStudyTitle, content = Page.Story.view model }
 
         Resource slug ->
             Theme.PageTemplate.view model

--- a/src/Page/Resource/Data.elm
+++ b/src/Page/Resource/Data.elm
@@ -10,7 +10,7 @@ type alias Resource =
     , fullTextMarkdown : String
     , maybeVideo : Maybe Page.Shared.VideoMeta
     , maybeAudio : Maybe Page.Shared.AudioMeta
-    , relatedCaseStudyList : List Page.Shared.CaseStudyTeaser
+    , relatedCaseStudyList : List Page.Shared.StoryTeaser
     , relatedResourceList : List Page.Shared.ResourceTeaser
     }
 

--- a/src/Page/Resource/Data.elm
+++ b/src/Page/Resource/Data.elm
@@ -10,7 +10,7 @@ type alias Resource =
     , fullTextMarkdown : String
     , maybeVideo : Maybe Page.Shared.VideoMeta
     , maybeAudio : Maybe Page.Shared.AudioMeta
-    , relatedCaseStudyList : List Page.Shared.StoryTeaser
+    , relatedStoryList : List Page.Shared.StoryTeaser
     , relatedResourceList : List Page.Shared.ResourceTeaser
     }
 
@@ -26,7 +26,7 @@ blankResource language =
     , fullTextMarkdown = t Resource404Body
     , maybeVideo = Nothing
     , maybeAudio = Nothing
-    , relatedCaseStudyList = []
+    , relatedStoryList = []
     , relatedResourceList = []
     }
 

--- a/src/Page/Resource/View.elm
+++ b/src/Page/Resource/View.elm
@@ -14,7 +14,7 @@ view resource =
         , p [] [ text resource.fullTextMarkdown ]
         , viewMaybeVideo resource.maybeVideo
         , viewMaybeAudio resource.maybeAudio
-        , viewRelatedCaseStudyTeasers resource.relatedStoryList
+        , viewRelatedStoryTeasers resource.relatedStoryList
         , viewRelatedResourceTeasers resource.relatedResourceList
         ]
 
@@ -39,15 +39,15 @@ viewMaybeAudio maybeAudioMeta =
             text ""
 
 
-viewRelatedCaseStudyTeasers : List Page.Shared.StoryTeaser -> Html Msg
-viewRelatedCaseStudyTeasers caseStudyList =
-    if List.length caseStudyList > 0 then
+viewRelatedStoryTeasers : List Page.Shared.StoryTeaser -> Html Msg
+viewRelatedStoryTeasers storyList =
+    if List.length storyList > 0 then
         ul []
             (List.map
                 (\{ title, url } ->
                     li [] [ a [ href url ] [ text title ] ]
                 )
-                caseStudyList
+                storyList
             )
 
     else

--- a/src/Page/Resource/View.elm
+++ b/src/Page/Resource/View.elm
@@ -39,7 +39,7 @@ viewMaybeAudio maybeAudioMeta =
             text ""
 
 
-viewRelatedCaseStudyTeasers : List Page.Shared.CaseStudyTeaser -> Html Msg
+viewRelatedCaseStudyTeasers : List Page.Shared.StoryTeaser -> Html Msg
 viewRelatedCaseStudyTeasers caseStudyList =
     if List.length caseStudyList > 0 then
         ul []

--- a/src/Page/Resource/View.elm
+++ b/src/Page/Resource/View.elm
@@ -14,7 +14,7 @@ view resource =
         , p [] [ text resource.fullTextMarkdown ]
         , viewMaybeVideo resource.maybeVideo
         , viewMaybeAudio resource.maybeAudio
-        , viewRelatedCaseStudyTeasers resource.relatedCaseStudyList
+        , viewRelatedCaseStudyTeasers resource.relatedStoryList
         , viewRelatedResourceTeasers resource.relatedResourceList
         ]
 

--- a/src/Page/Shared.elm
+++ b/src/Page/Shared.elm
@@ -1,4 +1,4 @@
-module Page.Shared exposing (AudioMeta, CaseStudyTeaser, ResourceTeaser, VideoMeta, viewAudio, viewVideo)
+module Page.Shared exposing (AudioMeta, ResourceTeaser, StoryTeaser, VideoMeta, viewAudio, viewVideo)
 
 import Html.Styled exposing (Html, div, iframe, text)
 import Html.Styled.Attributes exposing (attribute, autoplay, src, title)
@@ -17,7 +17,7 @@ type alias VideoMeta =
     }
 
 
-type alias CaseStudyTeaser =
+type alias StoryTeaser =
     { title : String
     , url : String
     }

--- a/src/Page/Story.elm
+++ b/src/Page/Story.elm
@@ -1,4 +1,4 @@
-module Page.CaseStudy exposing (view)
+module Page.Story exposing (view)
 
 import Html.Styled exposing (Html, div, text)
 import Shared exposing (Model, Msg)

--- a/src/Page/Story.elm
+++ b/src/Page/Story.elm
@@ -6,4 +6,4 @@ import Shared exposing (Model, Msg)
 
 view : Model -> Html Msg
 view model =
-    div [] [ text "Case Study content" ]
+    div [] [ text "Story content" ]

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -6,8 +6,8 @@ import Url.Parser as Parser exposing ((</>), Parser, map, oneOf, s, string, top)
 
 type Route
     = Index
-    | CaseStudyIndex
-    | CaseStudy String
+    | StoryIndex
+    | Story String
     | Resource String
 
 
@@ -23,11 +23,11 @@ toString route =
         Index ->
             "/"
 
-        CaseStudyIndex ->
-            "/case-study"
+        StoryIndex ->
+            "/stories"
 
-        CaseStudy s ->
-            "/case-study" ++ "/" ++ s
+        Story s ->
+            "/stories" ++ "/" ++ s
 
         Resource s ->
             "/resource" ++ "/" ++ s
@@ -37,7 +37,7 @@ routeParser : Parser (Route -> a) a
 routeParser =
     oneOf
         [ map Index top
-        , map CaseStudyIndex (s "case-study")
-        , map CaseStudy (s "case-study" </> string)
+        , map StoryIndex (s "stories")
+        , map Story (s "stories" </> string)
         , map Resource (s "resource" </> string)
         ]

--- a/tests/Resource.elm
+++ b/tests/Resource.elm
@@ -24,7 +24,7 @@ suite =
             , fullTextMarkdown = "# Some minimal test reource markdown"
             , maybeVideo = Nothing
             , maybeAudio = Nothing
-            , relatedCaseStudyList = []
+            , relatedStoryList = []
             , relatedResourceList = []
             }
 
@@ -42,7 +42,7 @@ suite =
                     { title = "An audio guide"
                     , src = "https://an.audio.guide"
                     }
-            , relatedCaseStudyList =
+            , relatedStoryList =
                 [ { title = "A related case study"
                   , url = "/a-case-study"
                   }

--- a/tests/Resource.elm
+++ b/tests/Resource.elm
@@ -43,11 +43,11 @@ suite =
                     , src = "https://an.audio.guide"
                     }
             , relatedStoryList =
-                [ { title = "A related case study"
-                  , url = "/a-case-study"
+                [ { title = "A related story"
+                  , url = "/a-story"
                   }
-                , { title = "Another related case study"
-                  , url = "/another-case-study"
+                , { title = "Another related story"
+                  , url = "/another-story"
                   }
                 ]
             , relatedResourceList =
@@ -87,13 +87,13 @@ suite =
                     queryFromStyledHtml (view resourceFull)
                         |> Query.contains
                             [ Html.text "[fFf] render audio player" ]
-            , test "Resource view can have related case study teasers" <|
+            , test "Resource view can have related story teasers" <|
                 \() ->
                     queryFromStyledHtml (view resourceFull)
                         |> Query.contains
                             [ Html.ul []
-                                [ Html.li [] [ Html.a [ Html.Attributes.href "/a-case-study" ] [ Html.text "A related case study" ] ]
-                                , Html.li [] [ Html.a [ Html.Attributes.href "/another-case-study" ] [ Html.text "Another related case study" ] ]
+                                [ Html.li [] [ Html.a [ Html.Attributes.href "/a-story" ] [ Html.text "A related story" ] ]
+                                , Html.li [] [ Html.a [ Html.Attributes.href "/another-story" ] [ Html.text "Another related story" ] ]
                                 ]
                             ]
             , test "Resource view can have related resource teasers" <|


### PR DESCRIPTION
Fixes #68 #69

## Description

- public facing text is now "story" instead of "case study"
- routes are now `stories/X`
- variable names match new language

@geeksforsocialchange/developers
