### PR TITLE
59 rename resource and case study

### DIFF
--- a/src/I18n/Cy.elm
+++ b/src/I18n/Cy.elm
@@ -12,8 +12,8 @@ cyStrings key =
         StoryTitle ->
             "[cCc] Story CY"
 
-        ResourceTitle ->
-            "[cCc] Resource CY"
+        GuideTitle ->
+            "[cCc] Guide CY"
 
         ChangeLanguage ->
             "[cCc] Switch to English"

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -15,8 +15,8 @@ enStrings key =
         StoryTitle ->
             "[cCc] Story"
 
-        ResourceTitle ->
-            "[cCc] Resource"
+        GuideTitle ->
+            "[cCc] Guide"
 
         ---
         -- Header
@@ -27,10 +27,10 @@ enStrings key =
         ---
         -- 404 content
         ---
-        Resource404Title ->
+        Guide404Title ->
             "[cCc] Sorry, we can't find that guide"
 
-        Resource404Body ->
+        Guide404Body ->
             "[cCc] Try searching again [home](\"\\\")"
 
         ---

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -5,11 +5,11 @@ type Key
     = SiteTitle
       --- Page Titles
     | StoryTitle
-    | ResourceTitle
+    | GuideTitle
     | ChangeLanguage
       --- 404 content
-    | Resource404Title
-    | Resource404Body
+    | Guide404Title
+    | Guide404Body
       --- Footer
     | FooterProjectInfo
     | FooterTitleColumnA

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -106,7 +106,7 @@ view model =
             Theme.PageTemplate.view model
                 { title = StoryTitle, content = Page.Story.view model }
 
-        Resource slug ->
+        Guide slug ->
             Theme.PageTemplate.view model
                 { title = ResourceTitle
                 , content =

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -108,7 +108,7 @@ view model =
 
         Guide slug ->
             Theme.PageTemplate.view model
-                { title = ResourceTitle
+                { title = GuideTitle
                 , content =
                     Page.Guide.View.view (Page.Guide.Data.guideFromSlug model.language slug)
                 }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -110,5 +110,5 @@ view model =
             Theme.PageTemplate.view model
                 { title = ResourceTitle
                 , content =
-                    Page.Guide.View.view (Page.Guide.Data.resourceFromSlug model.language slug)
+                    Page.Guide.View.view (Page.Guide.Data.guideFromSlug model.language slug)
                 }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -5,9 +5,9 @@ import Browser.Navigation
 import Html.Styled exposing (Html, toUnstyled)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..))
+import Page.Guide.Data
+import Page.Guide.View
 import Page.Index
-import Page.Resource.Data
-import Page.Resource.View
 import Page.Story
 import Route exposing (Route(..))
 import Shared exposing (Model, Msg(..))
@@ -110,5 +110,5 @@ view model =
             Theme.PageTemplate.view model
                 { title = ResourceTitle
                 , content =
-                    Page.Resource.View.view (Page.Resource.Data.resourceFromSlug model.language slug)
+                    Page.Guide.View.view (Page.Guide.Data.resourceFromSlug model.language slug)
                 }

--- a/src/Page/Guide/Data.elm
+++ b/src/Page/Guide/Data.elm
@@ -11,7 +11,7 @@ type alias Guide =
     , maybeVideo : Maybe Page.Shared.VideoMeta
     , maybeAudio : Maybe Page.Shared.AudioMeta
     , relatedStoryList : List Page.Shared.StoryTeaser
-    , relateGuideList : List Page.Shared.ResourceTeaser
+    , relateGuideList : List Page.Shared.GuideTeaser
     }
 
 

--- a/src/Page/Guide/Data.elm
+++ b/src/Page/Guide/Data.elm
@@ -1,4 +1,4 @@
-module Page.Guide.Data exposing (Guide, resourceFromSlug)
+module Page.Guide.Data exposing (Guide, guideFromSlug)
 
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language, translate)
@@ -11,12 +11,12 @@ type alias Guide =
     , maybeVideo : Maybe Page.Shared.VideoMeta
     , maybeAudio : Maybe Page.Shared.AudioMeta
     , relatedStoryList : List Page.Shared.StoryTeaser
-    , relatedResourceList : List Page.Shared.ResourceTeaser
+    , relateGuideList : List Page.Shared.ResourceTeaser
     }
 
 
-blankResource : Language -> Guide
-blankResource language =
+blankGuide : Language -> Guide
+blankGuide language =
     let
         t : Key -> String
         t =
@@ -27,11 +27,11 @@ blankResource language =
     , maybeVideo = Nothing
     , maybeAudio = Nothing
     , relatedStoryList = []
-    , relatedResourceList = []
+    , relateGuideList = []
     }
 
 
-resourceFromSlug : Language -> String -> Guide
-resourceFromSlug language slug =
+guideFromSlug : Language -> String -> Guide
+guideFromSlug language slug =
     -- TODO populate from markdown
-    blankResource language
+    blankGuide language

--- a/src/Page/Guide/Data.elm
+++ b/src/Page/Guide/Data.elm
@@ -22,8 +22,8 @@ blankGuide language =
         t =
             translate language
     in
-    { title = t Resource404Title
-    , fullTextMarkdown = t Resource404Body
+    { title = t Guide404Title
+    , fullTextMarkdown = t Guide404Body
     , maybeVideo = Nothing
     , maybeAudio = Nothing
     , relatedStoryList = []

--- a/src/Page/Guide/Data.elm
+++ b/src/Page/Guide/Data.elm
@@ -1,11 +1,11 @@
-module Page.Resource.Data exposing (Resource, resourceFromSlug)
+module Page.Guide.Data exposing (Guide, resourceFromSlug)
 
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language, translate)
 import Page.Shared
 
 
-type alias Resource =
+type alias Guide =
     { title : String
     , fullTextMarkdown : String
     , maybeVideo : Maybe Page.Shared.VideoMeta
@@ -15,7 +15,7 @@ type alias Resource =
     }
 
 
-blankResource : Language -> Resource
+blankResource : Language -> Guide
 blankResource language =
     let
         t : Key -> String
@@ -31,7 +31,7 @@ blankResource language =
     }
 
 
-resourceFromSlug : Language -> String -> Resource
+resourceFromSlug : Language -> String -> Guide
 resourceFromSlug language slug =
     -- TODO populate from markdown
     blankResource language

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -8,14 +8,14 @@ import Shared exposing (Model, Msg)
 
 
 view : Page.Guide.Data.Guide -> Html Msg
-view resource =
+view guide =
     div []
-        [ h1 [] [ text resource.title ]
-        , p [] [ text resource.fullTextMarkdown ]
-        , viewMaybeVideo resource.maybeVideo
-        , viewMaybeAudio resource.maybeAudio
-        , viewRelatedStoryTeasers resource.relatedStoryList
-        , viewRelatedResourceTeasers resource.relatedResourceList
+        [ h1 [] [ text guide.title ]
+        , p [] [ text guide.fullTextMarkdown ]
+        , viewMaybeVideo guide.maybeVideo
+        , viewMaybeAudio guide.maybeAudio
+        , viewRelatedStoryTeasers guide.relatedStoryList
+        , viewRelatedGuideTeasers guide.relateGuideList
         ]
 
 
@@ -54,15 +54,15 @@ viewRelatedStoryTeasers storyList =
         text ""
 
 
-viewRelatedResourceTeasers : List Page.Shared.ResourceTeaser -> Html Msg
-viewRelatedResourceTeasers resourceList =
-    if List.length resourceList > 0 then
+viewRelatedGuideTeasers : List Page.Shared.ResourceTeaser -> Html Msg
+viewRelatedGuideTeasers guideList =
+    if List.length guideList > 0 then
         ul []
             (List.map
                 (\{ title, url } ->
                     li [] [ a [ href url ] [ text title ] ]
                 )
-                resourceList
+                guideList
             )
 
     else

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -1,13 +1,13 @@
-module Page.Resource.View exposing (view)
+module Page.Guide.View exposing (view)
 
 import Html.Styled exposing (Html, a, div, h1, li, p, text, ul)
 import Html.Styled.Attributes exposing (href)
-import Page.Resource.Data
+import Page.Guide.Data
 import Page.Shared
 import Shared exposing (Model, Msg)
 
 
-view : Page.Resource.Data.Resource -> Html Msg
+view : Page.Guide.Data.Guide -> Html Msg
 view resource =
     div []
         [ h1 [] [ text resource.title ]

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -54,7 +54,7 @@ viewRelatedStoryTeasers storyList =
         text ""
 
 
-viewRelatedGuideTeasers : List Page.Shared.ResourceTeaser -> Html Msg
+viewRelatedGuideTeasers : List Page.Shared.GuideTeaser -> Html Msg
 viewRelatedGuideTeasers guideList =
     if List.length guideList > 0 then
         ul []

--- a/src/Page/Shared.elm
+++ b/src/Page/Shared.elm
@@ -1,4 +1,4 @@
-module Page.Shared exposing (AudioMeta, ResourceTeaser, StoryTeaser, VideoMeta, viewAudio, viewVideo)
+module Page.Shared exposing (AudioMeta, GuideTeaser, StoryTeaser, VideoMeta, viewAudio, viewVideo)
 
 import Html.Styled exposing (Html, div, iframe, text)
 import Html.Styled.Attributes exposing (attribute, autoplay, src, title)
@@ -23,7 +23,7 @@ type alias StoryTeaser =
     }
 
 
-type alias ResourceTeaser =
+type alias GuideTeaser =
     { title : String
     , url : String
     }

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -8,7 +8,7 @@ type Route
     = Index
     | StoryIndex
     | Story String
-    | Resource String
+    | Guide String
 
 
 fromUrl : Url.Url -> Maybe Route
@@ -29,8 +29,8 @@ toString route =
         Story s ->
             "/stories" ++ "/" ++ s
 
-        Resource s ->
-            "/resource" ++ "/" ++ s
+        Guide s ->
+            "/guides" ++ "/" ++ s
 
 
 routeParser : Parser (Route -> a) a
@@ -39,5 +39,5 @@ routeParser =
         [ map Index top
         , map StoryIndex (s "stories")
         , map Story (s "stories" </> string)
-        , map Resource (s "resource" </> string)
+        , map Guide (s "guides" </> string)
         ]

--- a/tests/Guide.elm
+++ b/tests/Guide.elm
@@ -1,4 +1,4 @@
-module Resource exposing (suite)
+module Guide exposing (suite)
 
 import Expect exposing (Expectation)
 import Html
@@ -18,23 +18,23 @@ import TestUtils exposing (queryFromStyledHtml)
 suite : Test
 suite =
     let
-        resourceMinimal : Guide
-        resourceMinimal =
-            { title = "A minimal test resource"
+        guideMinimal : Guide
+        guideMinimal =
+            { title = "A minimal test guide"
             , fullTextMarkdown = "# Some minimal test reource markdown"
             , maybeVideo = Nothing
             , maybeAudio = Nothing
             , relatedStoryList = []
-            , relatedResourceList = []
+            , relateGuideList = []
             }
 
-        resourceFull : Guide
-        resourceFull =
-            { title = "A full test resource"
+        guideFull : Guide
+        guideFull =
+            { title = "A full test guide"
             , fullTextMarkdown = "# Some full test reource markdown"
             , maybeVideo =
                 Just
-                    { title = "A resource video"
+                    { title = "A guide video"
                     , src = "https://a.video.test"
                     }
             , maybeAudio =
@@ -50,59 +50,59 @@ suite =
                   , url = "/another-story"
                   }
                 ]
-            , relatedResourceList =
-                [ { title = "A related resource"
-                  , url = "/a-resource"
+            , relateGuideList =
+                [ { title = "A related guide"
+                  , url = "/a-guide"
                   }
-                , { title = "Another related resource"
-                  , url = "/another-resource"
+                , { title = "Another related guide"
+                  , url = "/another-guide"
                   }
                 ]
             }
 
         view =
-            Page.Resource.View.view
+            Page.Guide.View.view
     in
-    describe "Resource Page"
+    describe "Guide Page"
         [ describe "View tests"
-            [ test "Resource view has title" <|
+            [ test "Guide view has title" <|
                 \() ->
-                    queryFromStyledHtml (view resourceMinimal)
+                    queryFromStyledHtml (view guideMinimal)
                         |> Query.contains
-                            [ Html.h1 [] [ Html.text resourceMinimal.title ]
+                            [ Html.h1 [] [ Html.text guideMinimal.title ]
                             ]
-            , test "Resource view has a body" <|
+            , test "Guide view has a body" <|
                 \() ->
-                    queryFromStyledHtml (view resourceMinimal)
+                    queryFromStyledHtml (view guideMinimal)
                         |> Query.contains
-                            [ Html.p [] [ Html.text resourceMinimal.fullTextMarkdown ]
+                            [ Html.p [] [ Html.text guideMinimal.fullTextMarkdown ]
                             ]
-            , test "Resource view can have a video" <|
+            , test "Guide view can have a video" <|
                 \() ->
-                    queryFromStyledHtml (view resourceFull)
+                    queryFromStyledHtml (view guideFull)
                         |> Query.has
                             [ tag "iframe" ]
-            , test "Resource view can have audio" <|
+            , test "Guide view can have audio" <|
                 \() ->
-                    queryFromStyledHtml (view resourceFull)
+                    queryFromStyledHtml (view guideFull)
                         |> Query.contains
                             [ Html.text "[fFf] render audio player" ]
-            , test "Resource view can have related story teasers" <|
+            , test "Guide view can have related story teasers" <|
                 \() ->
-                    queryFromStyledHtml (view resourceFull)
+                    queryFromStyledHtml (view guideFull)
                         |> Query.contains
                             [ Html.ul []
                                 [ Html.li [] [ Html.a [ Html.Attributes.href "/a-story" ] [ Html.text "A related story" ] ]
                                 , Html.li [] [ Html.a [ Html.Attributes.href "/another-story" ] [ Html.text "Another related story" ] ]
                                 ]
                             ]
-            , test "Resource view can have related resource teasers" <|
+            , test "Guide view can have related guide teasers" <|
                 \() ->
-                    queryFromStyledHtml (view resourceFull)
+                    queryFromStyledHtml (view guideFull)
                         |> Query.contains
                             [ Html.ul []
-                                [ Html.li [] [ Html.a [ Html.Attributes.href "/a-resource" ] [ Html.text "A related resource" ] ]
-                                , Html.li [] [ Html.a [ Html.Attributes.href "/another-resource" ] [ Html.text "Another related resource" ] ]
+                                [ Html.li [] [ Html.a [ Html.Attributes.href "/a-guide" ] [ Html.text "A related guide" ] ]
+                                , Html.li [] [ Html.a [ Html.Attributes.href "/another-guide" ] [ Html.text "Another related guide" ] ]
                                 ]
                             ]
             ]

--- a/tests/Resource.elm
+++ b/tests/Resource.elm
@@ -5,8 +5,8 @@ import Html
 import Html.Attributes
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (translate)
-import Page.Resource.Data exposing (Resource)
-import Page.Resource.View exposing (view)
+import Page.Guide.Data exposing (Guide)
+import Page.Guide.View exposing (view)
 import Set
 import Test exposing (Test, describe, test)
 import Test.Html.Event as Event
@@ -18,7 +18,7 @@ import TestUtils exposing (queryFromStyledHtml)
 suite : Test
 suite =
     let
-        resourceMinimal : Resource
+        resourceMinimal : Guide
         resourceMinimal =
             { title = "A minimal test resource"
             , fullTextMarkdown = "# Some minimal test reource markdown"
@@ -28,7 +28,7 @@ suite =
             , relatedResourceList = []
             }
 
-        resourceFull : Resource
+        resourceFull : Guide
         resourceFull =
             { title = "A full test resource"
             , fullTextMarkdown = "# Some full test reource markdown"


### PR DESCRIPTION
Fixes #72 
Fixes #73

## Description


- public facing text is now "guide" instead of "resource"
- routes are now `guides/X`
- variable names match new language



@geeksforsocialchange/developers
