### PR TITLE
Add single story

### DIFF
--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -33,6 +33,12 @@ enStrings key =
         Resource404Body ->
             "[cCc] Try searching again [home](\"\\\")"
 
+        Story404Title ->
+            "[cCc] Sorry, we can't find that story"
+
+        Story404Body ->
+            "[cCc] Try searching again [home](\"\\\")"
+
         ---
         -- Footer
         ---

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -10,6 +10,8 @@ type Key
       --- 404 content
     | Resource404Title
     | Resource404Body
+    | Story404Title
+    | Story404Body
       --- Footer
     | FooterProjectInfo
     | FooterTitleColumnA

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -8,7 +8,8 @@ import I18n.Translate exposing (Language(..))
 import Page.Index
 import Page.Resource.Data
 import Page.Resource.View
-import Page.Story
+import Page.Stories.Data
+import Page.Stories.View
 import Route exposing (Route(..))
 import Shared exposing (Model, Msg(..))
 import Theme.PageTemplate
@@ -98,13 +99,12 @@ view model =
             Theme.PageTemplate.view model
                 { title = SiteTitle, content = Page.Index.view model }
 
-        StoryIndex ->
+        Story slug ->
             Theme.PageTemplate.view model
-                { title = StoryTitle, content = Page.Story.view model }
-
-        Story _ ->
-            Theme.PageTemplate.view model
-                { title = StoryTitle, content = Page.Story.view model }
+                { title = StoryTitle
+                , content =
+                    Page.Stories.View.view (Page.Stories.Data.storyFromSlug model.language slug)
+                }
 
         Resource slug ->
             Theme.PageTemplate.view model

--- a/src/Page/Stories/Data.elm
+++ b/src/Page/Stories/Data.elm
@@ -1,0 +1,33 @@
+module Page.Stories.Data exposing (Story, storyFromSlug)
+
+import I18n.Keys exposing (Key(..))
+import I18n.Translate exposing (Language, translate)
+import Page.Shared
+
+
+type alias Story =
+    { title : String
+    , fullTextMarkdown : String
+    , relatedStoryList : List Page.Shared.StoryTeaser
+    , relatedResourceList : List Page.Shared.ResourceTeaser
+    }
+
+
+blankStory : Language -> Story
+blankStory language =
+    let
+        t : Key -> String
+        t =
+            translate language
+    in
+    { title = t Story404Title
+    , fullTextMarkdown = t Story404Body
+    , relatedStoryList = []
+    , relatedResourceList = []
+    }
+
+
+storyFromSlug : Language -> String -> Story
+storyFromSlug language slug =
+    -- TODO populate from markdown
+    blankStory language

--- a/src/Page/Stories/Data.elm
+++ b/src/Page/Stories/Data.elm
@@ -7,9 +7,17 @@ import Page.Shared
 
 type alias Story =
     { title : String
-    , fullTextMarkdown : String
+    , description : String
+    , maybeMetadata : Maybe StoryMetaData
     , relatedStoryList : List Page.Shared.StoryTeaser
     , relatedResourceList : List Page.Shared.ResourceTeaser
+    }
+
+
+type alias StoryMetaData =
+    { location : String
+    , author : String
+    , images : List { src : String, alt : String }
     }
 
 
@@ -21,7 +29,23 @@ blankStory language =
             translate language
     in
     { title = t Story404Title
-    , fullTextMarkdown = t Story404Body
+    , description = t Story404Body
+    , maybeMetadata = Nothing
+    , relatedStoryList = []
+    , relatedResourceList = []
+    }
+
+
+testStory : Story
+testStory =
+    { title = "A test story"
+    , description = "Test description"
+    , maybeMetadata =
+        Just
+            { location = "Test location"
+            , author = "Test author"
+            , images = [ { src = "/images/wildlife-trust-logo.png", alt = "placeholder" } ]
+            }
     , relatedStoryList = []
     , relatedResourceList = []
     }
@@ -30,4 +54,4 @@ blankStory language =
 storyFromSlug : Language -> String -> Story
 storyFromSlug language slug =
     -- TODO populate from markdown
-    blankStory language
+    testStory

--- a/src/Page/Stories/View.elm
+++ b/src/Page/Stories/View.elm
@@ -1,7 +1,7 @@
 module Page.Stories.View exposing (view)
 
-import Html.Styled exposing (Html, a, div, h1, li, p, text, ul)
-import Html.Styled.Attributes exposing (href)
+import Html.Styled exposing (Html, a, div, h1, img, li, p, text, ul)
+import Html.Styled.Attributes exposing (alt, href, src)
 import Page.Shared
 import Page.Stories.Data
 import Shared exposing (Msg)
@@ -11,7 +11,18 @@ view : Page.Stories.Data.Story -> Html Msg
 view story =
     div []
         [ h1 [] [ text story.title ]
-        , p [] [ text story.fullTextMarkdown ]
+        , case story.maybeMetadata of
+            Just metadata ->
+                div []
+                    [ p [] [ text metadata.location ]
+                    , p [] [ text metadata.author ]
+                    , div []
+                        (List.map (\image -> img [ src image.src, alt image.alt ] []) metadata.images)
+                    , p [] [ text story.description ]
+                    ]
+
+            Nothing ->
+                p [] [ text story.description ]
         , viewRelatedStoryTeasers story.relatedStoryList
         , viewRelatedResourceTeasers story.relatedResourceList
         ]

--- a/src/Page/Stories/View.elm
+++ b/src/Page/Stories/View.elm
@@ -1,0 +1,47 @@
+module Page.Stories.View exposing (view)
+
+import Html.Styled exposing (Html, a, div, h1, li, p, text, ul)
+import Html.Styled.Attributes exposing (href)
+import Page.Shared
+import Page.Stories.Data
+import Shared exposing (Msg)
+
+
+view : Page.Stories.Data.Story -> Html Msg
+view story =
+    div []
+        [ h1 [] [ text story.title ]
+        , p [] [ text story.fullTextMarkdown ]
+        , viewRelatedStoryTeasers story.relatedStoryList
+        , viewRelatedResourceTeasers story.relatedResourceList
+        ]
+
+
+viewRelatedStoryTeasers : List Page.Shared.StoryTeaser -> Html Msg
+viewRelatedStoryTeasers storyList =
+    if List.length storyList > 0 then
+        ul []
+            (List.map
+                (\{ title, url } ->
+                    li [] [ a [ href url ] [ text title ] ]
+                )
+                storyList
+            )
+
+    else
+        text ""
+
+
+viewRelatedResourceTeasers : List Page.Shared.ResourceTeaser -> Html Msg
+viewRelatedResourceTeasers resourceList =
+    if List.length resourceList > 0 then
+        ul []
+            (List.map
+                (\{ title, url } ->
+                    li [] [ a [ href url ] [ text title ] ]
+                )
+                resourceList
+            )
+
+    else
+        text ""

--- a/src/Page/Story.elm
+++ b/src/Page/Story.elm
@@ -1,9 +1,0 @@
-module Page.Story exposing (view)
-
-import Html.Styled exposing (Html, div, text)
-import Shared exposing (Model, Msg)
-
-
-view : Model -> Html Msg
-view model =
-    div [] [ text "Story content" ]

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -6,7 +6,6 @@ import Url.Parser as Parser exposing ((</>), Parser, map, oneOf, s, string, top)
 
 type Route
     = Index
-    | StoryIndex
     | Story String
     | Resource String
 
@@ -23,9 +22,6 @@ toString route =
         Index ->
             "/"
 
-        StoryIndex ->
-            "/stories"
-
         Story s ->
             "/stories" ++ "/" ++ s
 
@@ -37,7 +33,6 @@ routeParser : Parser (Route -> a) a
 routeParser =
     oneOf
         [ map Index top
-        , map StoryIndex (s "stories")
         , map Story (s "stories" </> string)
         , map Resource (s "resource" </> string)
         ]

--- a/tests/Stories.elm
+++ b/tests/Stories.elm
@@ -5,6 +5,7 @@ import Html.Attributes
 import I18n.Keys exposing (Key(..))
 import Page.Stories.Data exposing (Story)
 import Page.Stories.View exposing (view)
+import Svg.Styled exposing (metadata)
 import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
 import TestUtils exposing (queryFromStyledHtml)
@@ -16,7 +17,8 @@ suite =
         storyMinimal : Story
         storyMinimal =
             { title = "A minimal test story"
-            , fullTextMarkdown = "# Some minimal test reource markdown"
+            , description = "# Some minimal test reource markdown"
+            , maybeMetadata = Nothing
             , relatedStoryList = []
             , relatedResourceList = []
             }
@@ -24,7 +26,13 @@ suite =
         storyFull : Story
         storyFull =
             { title = "A full test story"
-            , fullTextMarkdown = "# Some full test reource markdown"
+            , description = "# Some full test reource markdown"
+            , maybeMetadata =
+                Just
+                    { location = "Test location"
+                    , author = "Test author"
+                    , images = [ { src = "/images/wildlife-trust-logo.png", alt = "placeholder" } ]
+                    }
             , relatedStoryList =
                 [ { title = "A related story"
                   , url = "/a-story"
@@ -54,11 +62,11 @@ suite =
                         |> Query.contains
                             [ Html.h1 [] [ Html.text storyMinimal.title ]
                             ]
-            , test "Story view has a body" <|
+            , test "Story view has a description" <|
                 \() ->
                     queryFromStyledHtml (view storyMinimal)
                         |> Query.contains
-                            [ Html.p [] [ Html.text storyMinimal.fullTextMarkdown ]
+                            [ Html.p [] [ Html.text storyMinimal.description ]
                             ]
             , test "Story view can have related story teasers" <|
                 \() ->
@@ -78,5 +86,35 @@ suite =
                                 , Html.li [] [ Html.a [ Html.Attributes.href "/another-resource" ] [ Html.text "Another related resource" ] ]
                                 ]
                             ]
+            , test "Full story view has an author" <|
+                \() ->
+                    case storyFull.maybeMetadata of
+                        Just metadata ->
+                            queryFromStyledHtml (view storyFull)
+                                |> Query.contains
+                                    [ Html.p
+                                        []
+                                        [ Html.text metadata.author ]
+                                    ]
+
+                        Nothing ->
+                            queryFromStyledHtml (view storyFull)
+                                |> Query.contains
+                                    []
+            , test "Full story view has an image" <|
+                \() ->
+                    case storyFull.maybeMetadata of
+                        Just metadata ->
+                            queryFromStyledHtml (view storyFull)
+                                |> Query.contains
+                                    (List.map
+                                        (\image -> Html.img [ Html.Attributes.alt image.alt, Html.Attributes.src image.src ] [])
+                                        metadata.images
+                                    )
+
+                        Nothing ->
+                            queryFromStyledHtml (view storyFull)
+                                |> Query.contains
+                                    []
             ]
         ]

--- a/tests/Stories.elm
+++ b/tests/Stories.elm
@@ -1,0 +1,82 @@
+module Stories exposing (suite)
+
+import Html
+import Html.Attributes
+import I18n.Keys exposing (Key(..))
+import Page.Stories.Data exposing (Story)
+import Page.Stories.View exposing (view)
+import Test exposing (Test, describe, test)
+import Test.Html.Query as Query
+import TestUtils exposing (queryFromStyledHtml)
+
+
+suite : Test
+suite =
+    let
+        storyMinimal : Story
+        storyMinimal =
+            { title = "A minimal test story"
+            , fullTextMarkdown = "# Some minimal test reource markdown"
+            , relatedStoryList = []
+            , relatedResourceList = []
+            }
+
+        storyFull : Story
+        storyFull =
+            { title = "A full test story"
+            , fullTextMarkdown = "# Some full test reource markdown"
+            , relatedStoryList =
+                [ { title = "A related story"
+                  , url = "/a-story"
+                  }
+                , { title = "Another related story"
+                  , url = "/another-story"
+                  }
+                ]
+            , relatedResourceList =
+                [ { title = "A related resource"
+                  , url = "/a-resource"
+                  }
+                , { title = "Another related resource"
+                  , url = "/another-resource"
+                  }
+                ]
+            }
+
+        view =
+            Page.Stories.View.view
+    in
+    describe "Story Page"
+        [ describe "View tests"
+            [ test "Story view has title" <|
+                \() ->
+                    queryFromStyledHtml (view storyMinimal)
+                        |> Query.contains
+                            [ Html.h1 [] [ Html.text storyMinimal.title ]
+                            ]
+            , test "Story view has a body" <|
+                \() ->
+                    queryFromStyledHtml (view storyMinimal)
+                        |> Query.contains
+                            [ Html.p [] [ Html.text storyMinimal.fullTextMarkdown ]
+                            ]
+            , test "Story view can have related story teasers" <|
+                \() ->
+                    queryFromStyledHtml (view storyFull)
+                        |> Query.contains
+                            [ Html.ul []
+                                [ Html.li [] [ Html.a [ Html.Attributes.href "/a-story" ] [ Html.text "A related story" ] ]
+                                , Html.li [] [ Html.a [ Html.Attributes.href "/another-story" ] [ Html.text "Another related story" ] ]
+                                ]
+                            ]
+            , test "Story view can have related resource teasers" <|
+                \() ->
+                    queryFromStyledHtml (view storyFull)
+                        |> Query.contains
+                            [ Html.ul []
+                                [ Html.li [] [ Html.a [ Html.Attributes.href "/a-resource" ] [ Html.text "A related resource" ] ]
+                                , Html.li [] [ Html.a [ Html.Attributes.href "/another-resource" ] [ Html.text "Another related resource" ] ]
+                                ]
+                            ]
+            ]
+        ]


### PR DESCRIPTION
Fixes #64 

## Description

- Adds a single story view & data model, copying the pattern established for guides (formerly resources) 
- For now a single story is blank, as in guides, but the data model allows for the addition of a title, author, location, images, and description. 
- Adds tests to assert data displays correctly

@geeksforsocialchange/developers

I've designed this so that if any data is added then all data must be added, as per the proposed layout which suggested an image was required in order for a story to be published, but I'm now questioning if this is the right way to go and instead should any of these fields should be optional?