### PR TITLE
Show list of related story teasers on guide page

### DIFF
--- a/src/Page/Guide/Data.elm
+++ b/src/Page/Guide/Data.elm
@@ -26,7 +26,13 @@ blankGuide language =
     , fullTextMarkdown = t Guide404Body
     , maybeVideo = Nothing
     , maybeAudio = Nothing
-    , relatedStoryList = []
+    , relatedStoryList =
+        --- [fFf] to be replaced
+        [ { title = "Test story teaser", url = "/", image = { src = "/images/wildlife-trust-logo.png", alt = "placeholder" }, description = "A test description" }
+        , { title = "Test story teaser", url = "/", image = { src = "/images/wildlife-trust-logo.png", alt = "placeholder" }, description = "A test description" }
+        , { title = "Test story teaser", url = "/", image = { src = "/images/wildlife-trust-logo.png", alt = "placeholder" }, description = "A test description" }
+        , { title = "Test story teaser", url = "/", image = { src = "/images/wildlife-trust-logo.png", alt = "placeholder" }, description = "A test description" }
+        ]
     , relateGuideList = []
     }
 

--- a/src/Page/Guide/Data.elm
+++ b/src/Page/Guide/Data.elm
@@ -28,10 +28,10 @@ blankGuide language =
     , maybeAudio = Nothing
     , relatedStoryList =
         --- [fFf] to be replaced
-        [ { title = "Test story teaser", url = "/", image = { src = "/images/wildlife-trust-logo.png", alt = "placeholder" }, description = "A test description" }
-        , { title = "Test story teaser", url = "/", image = { src = "/images/wildlife-trust-logo.png", alt = "placeholder" }, description = "A test description" }
-        , { title = "Test story teaser", url = "/", image = { src = "/images/wildlife-trust-logo.png", alt = "placeholder" }, description = "A test description" }
-        , { title = "Test story teaser", url = "/", image = { src = "/images/wildlife-trust-logo.png", alt = "placeholder" }, description = "A test description" }
+        [ { title = "Test story teaser", slug = "test-story", image = { src = "/images/wildlife-trust-logo.png", alt = "placeholder" }, description = "A test description" }
+        , { title = "Test story teaser", slug = "test-story", image = { src = "/images/wildlife-trust-logo.png", alt = "placeholder" }, description = "A test description" }
+        , { title = "Test story teaser", slug = "test-story", image = { src = "/images/wildlife-trust-logo.png", alt = "placeholder" }, description = "A test description" }
+        , { title = "Test story teaser", slug = "test-story", image = { src = "/images/wildlife-trust-logo.png", alt = "placeholder" }, description = "A test description" }
         ]
     , relateGuideList = []
     }

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -4,7 +4,7 @@ import Html.Styled exposing (Html, a, div, h1, li, p, text, ul)
 import Html.Styled.Attributes exposing (href)
 import Page.Guide.Data
 import Page.Shared
-import Shared exposing (Model, Msg)
+import Shared exposing (Msg)
 
 
 view : Page.Guide.Data.Guide -> Html Msg
@@ -14,7 +14,7 @@ view guide =
         , p [] [ text guide.fullTextMarkdown ]
         , viewMaybeVideo guide.maybeVideo
         , viewMaybeAudio guide.maybeAudio
-        , viewRelatedStoryTeasers guide.relatedStoryList
+        , Page.Shared.viewStoryTeasers guide.relatedStoryList
         , viewRelatedGuideTeasers guide.relateGuideList
         ]
 
@@ -37,21 +37,6 @@ viewMaybeAudio maybeAudioMeta =
 
         Nothing ->
             text ""
-
-
-viewRelatedStoryTeasers : List Page.Shared.StoryTeaser -> Html Msg
-viewRelatedStoryTeasers storyList =
-    if List.length storyList > 0 then
-        ul []
-            (List.map
-                (\{ title, url } ->
-                    li [] [ a [ href url ] [ text title ] ]
-                )
-                storyList
-            )
-
-    else
-        text ""
 
 
 viewRelatedGuideTeasers : List Page.Shared.GuideTeaser -> Html Msg

--- a/src/Page/Shared.elm
+++ b/src/Page/Shared.elm
@@ -21,7 +21,7 @@ type alias VideoMeta =
 
 type alias StoryTeaser =
     { title : String
-    , url : String
+    , slug : String
     , image : { src : String, alt : String }
     , description : String
     }
@@ -78,10 +78,10 @@ viewStoryTeasers teasers =
             (teasers
                 |> sortBy .title
                 |> map
-                    (\{ url, title, image, description } ->
+                    (\{ description, image, slug, title } ->
                         div [ css [ storyTeaserStyle ] ]
                             [ img [ src image.src, alt image.alt ] []
-                            , a [ href url ] [ text title ]
+                            , a [ href ("/stories/" ++ slug) ] [ text title ]
                             , p [] [ text description ]
                             ]
                     )

--- a/src/Page/Shared.elm
+++ b/src/Page/Shared.elm
@@ -1,7 +1,8 @@
-module Page.Shared exposing (AudioMeta, GuideTeaser, StoryTeaser, VideoMeta, guideTeaserList, viewAudio, viewGuideTeaserList, viewVideo)
+module Page.Shared exposing (AudioMeta, GuideTeaser, StoryTeaser, VideoMeta, guideTeaserList, viewAudio, viewGuideTeaserList, viewStoryTeasers, viewVideo)
 
-import Html.Styled exposing (Html, a, div, iframe, li, text, ul)
-import Html.Styled.Attributes exposing (attribute, autoplay, href, src, title)
+import Css exposing (Style, batch, center, column, displayFlex, flexDirection, flexWrap, height, justifyContent, maxWidth, px, wrap)
+import Html.Styled exposing (Html, a, div, iframe, img, li, p, text, ul)
+import Html.Styled.Attributes exposing (alt, attribute, autoplay, css, href, src, title)
 import List exposing (map, sortBy)
 import Shared exposing (Msg)
 
@@ -21,6 +22,8 @@ type alias VideoMeta =
 type alias StoryTeaser =
     { title : String
     , url : String
+    , image : { src : String, alt : String }
+    , description : String
     }
 
 
@@ -66,6 +69,47 @@ viewGuideTeaserList teasers =
 
     else
         text ""
+
+
+viewStoryTeasers : List StoryTeaser -> Html Msg
+viewStoryTeasers teasers =
+    if List.length teasers > 0 then
+        div [ css [ viewStoryTeasersStyle ] ]
+            (teasers
+                |> sortBy .title
+                |> map
+                    (\{ url, title, image, description } ->
+                        div [ css [ storyTeaserStyle ] ]
+                            [ img [ src image.src, alt image.alt ] []
+                            , a [ href url ] [ text title ]
+                            , p [] [ text description ]
+                            ]
+                    )
+            )
+
+    else
+        text ""
+
+
+viewStoryTeasersStyle : Style
+viewStoryTeasersStyle =
+    batch
+        [ justifyContent center
+        , displayFlex
+        , flexWrap wrap
+        , maxWidth (px 400)
+        ]
+
+
+storyTeaserStyle : Style
+storyTeaserStyle =
+    batch
+        [ justifyContent center
+        , displayFlex
+        , flexDirection column
+        , height (px 150)
+        , maxWidth (px 150)
+        ]
 
 
 

--- a/src/Page/Stories/Data.elm
+++ b/src/Page/Stories/Data.elm
@@ -9,7 +9,6 @@ type alias Story =
     { title : String
     , description : String
     , maybeMetadata : Maybe StoryMetaData
-    , relatedStoryList : List Page.Shared.StoryTeaser
     , relatedGuideList : List Page.Shared.GuideTeaser
     }
 
@@ -31,9 +30,12 @@ blankStory language =
     { title = t Story404Title
     , description = t Story404Body
     , maybeMetadata = Nothing
-    , relatedStoryList = []
     , relatedGuideList = []
     }
+
+
+
+--- [fFf] test story to be removed
 
 
 testStory : Story
@@ -46,7 +48,6 @@ testStory =
             , author = "Test author"
             , images = [ { src = "/images/wildlife-trust-logo.png", alt = "placeholder" } ]
             }
-    , relatedStoryList = []
     , relatedGuideList = []
     }
 

--- a/src/Page/Stories/View.elm
+++ b/src/Page/Stories/View.elm
@@ -23,24 +23,8 @@ view story =
 
             Nothing ->
                 p [] [ text story.description ]
-        , viewRelatedStoryTeasers story.relatedStoryList
         , viewRelatedGuideTeasers story.relatedGuideList
         ]
-
-
-viewRelatedStoryTeasers : List Page.Shared.StoryTeaser -> Html Msg
-viewRelatedStoryTeasers storyList =
-    if List.length storyList > 0 then
-        ul []
-            (List.map
-                (\{ title, url } ->
-                    li [] [ a [ href url ] [ text title ] ]
-                )
-                storyList
-            )
-
-    else
-        text ""
 
 
 viewRelatedGuideTeasers : List Page.Shared.GuideTeaser -> Html Msg

--- a/tests/Guide.elm
+++ b/tests/Guide.elm
@@ -1,17 +1,13 @@
 module Guide exposing (suite)
 
-import Expect exposing (Expectation)
 import Html
 import Html.Attributes
 import I18n.Keys exposing (Key(..))
-import I18n.Translate exposing (translate)
 import Page.Guide.Data exposing (Guide)
 import Page.Guide.View exposing (view)
-import Set
 import Test exposing (Test, describe, test)
-import Test.Html.Event as Event
 import Test.Html.Query as Query
-import Test.Html.Selector exposing (attribute, containing, tag, text)
+import Test.Html.Selector exposing (tag)
 import TestUtils exposing (queryFromStyledHtml)
 
 
@@ -44,10 +40,14 @@ suite =
                     }
             , relatedStoryList =
                 [ { title = "A related story"
-                  , url = "/a-story"
+                  , slug = "a-story"
+                  , image = { src = "/", alt = "" }
+                  , description = "test description"
                   }
                 , { title = "Another related story"
-                  , url = "/another-story"
+                  , slug = "another-story"
+                  , image = { src = "/", alt = "" }
+                  , description = "test description"
                   }
                 ]
             , relateGuideList =
@@ -91,11 +91,7 @@ suite =
                 \() ->
                     queryFromStyledHtml (view guideFull)
                         |> Query.contains
-                            [ Html.ul []
-                                [ Html.li [] [ Html.a [ Html.Attributes.href "/a-story" ] [ Html.text "A related story" ] ]
-                                , Html.li [] [ Html.a [ Html.Attributes.href "/another-story" ] [ Html.text "Another related story" ] ]
-                                ]
-                            ]
+                            [ Html.a [ Html.Attributes.href "/stories/another-story" ] [ Html.text "Another related story" ] ]
             , test "Guide view can have related guide teasers" <|
                 \() ->
                     queryFromStyledHtml (view guideFull)

--- a/tests/Stories.elm
+++ b/tests/Stories.elm
@@ -19,7 +19,6 @@ suite =
             { title = "A minimal test story"
             , description = "# Some minimal test reource markdown"
             , maybeMetadata = Nothing
-            , relatedStoryList = []
             , relatedGuideList = []
             }
 
@@ -33,14 +32,6 @@ suite =
                     , author = "Test author"
                     , images = [ { src = "/images/wildlife-trust-logo.png", alt = "placeholder" } ]
                     }
-            , relatedStoryList =
-                [ { title = "A related story"
-                  , url = "/a-story"
-                  }
-                , { title = "Another related story"
-                  , url = "/another-story"
-                  }
-                ]
             , relatedGuideList =
                 [ { title = "A related guide"
                   , url = "/a-guide"
@@ -67,15 +58,6 @@ suite =
                     queryFromStyledHtml (view storyMinimal)
                         |> Query.contains
                             [ Html.p [] [ Html.text storyMinimal.description ]
-                            ]
-            , test "Story view can have related story teasers" <|
-                \() ->
-                    queryFromStyledHtml (view storyFull)
-                        |> Query.contains
-                            [ Html.ul []
-                                [ Html.li [] [ Html.a [ Html.Attributes.href "/a-story" ] [ Html.text "A related story" ] ]
-                                , Html.li [] [ Html.a [ Html.Attributes.href "/another-story" ] [ Html.text "Another related story" ] ]
-                                ]
                             ]
             , test "Story view can have related guide teasers" <|
                 \() ->


### PR DESCRIPTION
Fixes #65 

## Description

- Adds a component to show a list of related story teasers
- Adds some very basic layout styling to show each teaser as an image, link and description  & restrict sizing to something sensible while we work on this
- Updates tests and removes incorrect logic from Story view (originally this also included these but not needed)

@geeksforsocialchange/developers
