### PR TITLE
Guide markdown rendering

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -6,6 +6,7 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
+            "dillonkearns/elm-markdown": "7.0.1",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
@@ -16,6 +17,7 @@
         "indirect": {
             "elm/html": "1.0.0",
             "elm/parser": "1.1.0",
+            "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
             "robinheghan/murmur3": "1.0.0",

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -1,17 +1,18 @@
 module Page.Guide.View exposing (view)
 
-import Html.Styled exposing (Html, a, div, h1, li, p, text, ul)
+import Html.Styled as Html exposing (a, div, fromUnstyled, h1, li, p, text, ul)
 import Html.Styled.Attributes exposing (href)
 import Message exposing (Msg)
 import Page.Guide.Data
 import Page.Shared.View
+import Theme.Markdown exposing (markdownToHtml)
 
 
-view : Page.Guide.Data.Guide -> Html Msg
+view : Page.Guide.Data.Guide -> Html.Html Msg
 view guide =
     div []
         [ h1 [] [ text guide.title ]
-        , p [] [ text guide.fullTextMarkdown ]
+        , div [] (markdownToHtml guide.fullTextMarkdown)
         , viewMaybeVideo guide.maybeVideo
         , viewMaybeAudio guide.maybeAudio
         , Page.Shared.View.viewStoryTeasers guide.relatedStoryList
@@ -19,7 +20,7 @@ view guide =
         ]
 
 
-viewMaybeVideo : Maybe Page.Shared.View.VideoMeta -> Html Msg
+viewMaybeVideo : Maybe Page.Shared.View.VideoMeta -> Html.Html Msg
 viewMaybeVideo maybeVideoMeta =
     case maybeVideoMeta of
         Just aVideo ->
@@ -29,7 +30,7 @@ viewMaybeVideo maybeVideoMeta =
             text ""
 
 
-viewMaybeAudio : Maybe Page.Shared.View.AudioMeta -> Html Msg
+viewMaybeAudio : Maybe Page.Shared.View.AudioMeta -> Html.Html Msg
 viewMaybeAudio maybeAudioMeta =
     case maybeAudioMeta of
         Just anAudio ->
@@ -39,7 +40,7 @@ viewMaybeAudio maybeAudioMeta =
             text ""
 
 
-viewRelatedGuideTeasers : List Page.Shared.View.GuideTeaser -> Html Msg
+viewRelatedGuideTeasers : List Page.Shared.View.GuideTeaser -> Html.Html Msg
 viewRelatedGuideTeasers guideList =
     if List.length guideList > 0 then
         ul []

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -1,6 +1,6 @@
 module Page.Guide.View exposing (view)
 
-import Html.Styled as Html exposing (a, div, fromUnstyled, h1, li, p, text, ul)
+import Html.Styled exposing (Html, a, div, h1, li, p, text, ul)
 import Html.Styled.Attributes exposing (href)
 import Message exposing (Msg)
 import Page.Guide.Data
@@ -8,7 +8,7 @@ import Page.Shared.View
 import Theme.Markdown exposing (markdownToHtml)
 
 
-view : Page.Guide.Data.Guide -> Html.Html Msg
+view : Page.Guide.Data.Guide -> Html Msg
 view guide =
     div []
         [ h1 [] [ text guide.title ]
@@ -20,7 +20,7 @@ view guide =
         ]
 
 
-viewMaybeVideo : Maybe Page.Shared.View.VideoMeta -> Html.Html Msg
+viewMaybeVideo : Maybe Page.Shared.View.VideoMeta -> Html Msg
 viewMaybeVideo maybeVideoMeta =
     case maybeVideoMeta of
         Just aVideo ->
@@ -30,7 +30,7 @@ viewMaybeVideo maybeVideoMeta =
             text ""
 
 
-viewMaybeAudio : Maybe Page.Shared.View.AudioMeta -> Html.Html Msg
+viewMaybeAudio : Maybe Page.Shared.View.AudioMeta -> Html Msg
 viewMaybeAudio maybeAudioMeta =
     case maybeAudioMeta of
         Just anAudio ->
@@ -40,7 +40,7 @@ viewMaybeAudio maybeAudioMeta =
             text ""
 
 
-viewRelatedGuideTeasers : List Page.Shared.View.GuideTeaser -> Html.Html Msg
+viewRelatedGuideTeasers : List Page.Shared.View.GuideTeaser -> Html Msg
 viewRelatedGuideTeasers guideList =
     if List.length guideList > 0 then
         ul []

--- a/src/Theme/Markdown.elm
+++ b/src/Theme/Markdown.elm
@@ -1,0 +1,242 @@
+module Theme.Markdown exposing (markdownToHtml, markdownToView)
+
+import Css exposing (Style, absolute, batch, before, center, color, decimal, em, firstChild, fontSize, fontWeight, int, left, lineHeight, listStyle, listStyleType, marginBlockEnd, marginBlockStart, none, paddingLeft, position, property, relative, rem, textAlign, top)
+import Html.Styled as Html
+import Html.Styled.Attributes as Attr exposing (css)
+import Markdown.Block as Block
+import Markdown.Html
+import Markdown.Parser
+import Markdown.Renderer
+
+
+markdownToHtml : String -> List (Html.Html msg)
+markdownToHtml markdown =
+    case markdownToView markdown of
+        Ok html ->
+            html
+
+        Err _ ->
+            []
+
+
+markdownToView : String -> Result String (List (Html.Html msg))
+markdownToView markdownString =
+    markdownString
+        |> Markdown.Parser.parse
+        |> Result.mapError (\_ -> "Markdown error.")
+        |> Result.andThen
+            (\blocks ->
+                Markdown.Renderer.render
+                    transHtmlRenderer
+                    blocks
+            )
+
+
+transHtmlRenderer : Markdown.Renderer.Renderer (Html.Html msg)
+transHtmlRenderer =
+    { heading =
+        \{ level, children } ->
+            case level of
+                Block.H1 ->
+                    Html.h1 [ css [ headerStyle ] ] children
+
+                Block.H2 ->
+                    Html.h2 [ css [ headerStyle, h2Style ] ] children
+
+                Block.H3 ->
+                    Html.h3 [ css [ headerStyle ] ] children
+
+                Block.H4 ->
+                    Html.h4 [ css [ headerStyle ] ] children
+
+                Block.H5 ->
+                    Html.h5 [ css [ headerStyle ] ] children
+
+                Block.H6 ->
+                    Html.h6 [ css [ headerStyle ] ] children
+    , paragraph = Html.p [ css [ paragraphStyle ] ]
+    , hardLineBreak = Html.br [] []
+    , strikethrough =
+        \children -> Html.s [] children
+    , blockQuote = Html.blockquote []
+    , strong =
+        \children -> Html.strong [] children
+    , emphasis =
+        \children -> Html.em [] children
+    , codeSpan =
+        \content -> Html.code [] [ Html.text content ]
+    , link =
+        \link content ->
+            case link.title of
+                Just title ->
+                    Html.a
+                        [ Attr.href link.destination
+                        , Attr.title title
+                        , css []
+                        ]
+                        content
+
+                Nothing ->
+                    Html.a [ Attr.href link.destination, css [] ] content
+    , image =
+        \imageInfo ->
+            case imageInfo.title of
+                Just title ->
+                    Html.img
+                        [ Attr.src imageInfo.src
+                        , Attr.alt imageInfo.alt
+                        , Attr.title title
+                        ]
+                        []
+
+                Nothing ->
+                    Html.img
+                        [ Attr.src imageInfo.src
+                        , Attr.alt imageInfo.alt
+                        ]
+                        []
+    , text =
+        Html.text
+    , unorderedList =
+        \items ->
+            Html.ul [ css [ ulStyle ] ]
+                (items
+                    |> List.map
+                        (\item ->
+                            case item of
+                                Block.ListItem task children ->
+                                    let
+                                        checkbox =
+                                            case task of
+                                                Block.NoTask ->
+                                                    Html.text ""
+
+                                                Block.IncompleteTask ->
+                                                    Html.input
+                                                        [ Attr.disabled True
+                                                        , Attr.checked False
+                                                        , Attr.type_ "checkbox"
+                                                        ]
+                                                        []
+
+                                                Block.CompletedTask ->
+                                                    Html.input
+                                                        [ Attr.disabled True
+                                                        , Attr.checked True
+                                                        , Attr.type_ "checkbox"
+                                                        ]
+                                                        []
+                                    in
+                                    Html.li [ css [ ulLiStyle ] ] (checkbox :: children)
+                        )
+                )
+    , orderedList =
+        \startingIndex items ->
+            Html.ol
+                (case startingIndex of
+                    1 ->
+                        [ Attr.start startingIndex, css [ olStyle ] ]
+
+                    _ ->
+                        []
+                )
+                (items
+                    |> List.map
+                        (\itemBlocks ->
+                            Html.li [ css [ olLiStyle ] ]
+                                itemBlocks
+                        )
+                )
+    , html = Markdown.Html.oneOf []
+    , codeBlock =
+        \{ body, language } ->
+            Html.pre []
+                [ Html.code []
+                    [ Html.text body
+                    ]
+                ]
+    , thematicBreak = Html.hr [] []
+    , table = Html.table []
+    , tableHeader = Html.thead []
+    , tableBody = Html.tbody []
+    , tableRow = Html.tr []
+    , tableHeaderCell =
+        \maybeAlignment ->
+            let
+                attrs =
+                    maybeAlignment
+                        |> Maybe.map
+                            (\alignment ->
+                                case alignment of
+                                    Block.AlignLeft ->
+                                        "left"
+
+                                    Block.AlignCenter ->
+                                        "center"
+
+                                    Block.AlignRight ->
+                                        "right"
+                            )
+                        |> Maybe.map Attr.align
+                        |> Maybe.map List.singleton
+                        |> Maybe.withDefault []
+            in
+            Html.th attrs
+    , tableCell =
+        \maybeAlignment ->
+            let
+                attrs =
+                    maybeAlignment
+                        |> Maybe.map
+                            (\alignment ->
+                                case alignment of
+                                    Block.AlignLeft ->
+                                        "left"
+
+                                    Block.AlignCenter ->
+                                        "center"
+
+                                    Block.AlignRight ->
+                                        "right"
+                            )
+                        |> Maybe.map Attr.align
+                        |> Maybe.map List.singleton
+                        |> Maybe.withDefault []
+            in
+            Html.td attrs
+    }
+
+
+headerStyle : Style
+headerStyle =
+    batch []
+
+
+h2Style : Style
+h2Style =
+    batch []
+
+
+paragraphStyle : Style
+paragraphStyle =
+    batch []
+
+
+ulStyle : Style
+ulStyle =
+    batch []
+
+
+olStyle : Style
+olStyle =
+    batch []
+
+
+ulLiStyle : Style
+ulLiStyle =
+    batch []
+
+
+olLiStyle : Style
+olLiStyle =
+    batch []

--- a/src/Theme/Markdown.elm
+++ b/src/Theme/Markdown.elm
@@ -27,13 +27,13 @@ markdownToView markdownString =
         |> Result.andThen
             (\blocks ->
                 Markdown.Renderer.render
-                    transHtmlRenderer
+                    htmlRenderer
                     blocks
             )
 
 
-transHtmlRenderer : Markdown.Renderer.Renderer (Html.Html msg)
-transHtmlRenderer =
+htmlRenderer : Markdown.Renderer.Renderer (Html.Html msg)
+htmlRenderer =
     { heading =
         \{ level, children } ->
             case level of

--- a/tests/Guide.elm
+++ b/tests/Guide.elm
@@ -7,7 +7,7 @@ import Page.Guide.Data exposing (Guide)
 import Page.Guide.View exposing (view)
 import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
-import Test.Html.Selector exposing (tag)
+import Test.Html.Selector exposing (tag, classes, text)
 import TestUtils exposing (queryFromStyledHtml)
 
 
@@ -29,7 +29,7 @@ suite =
         guideFull =
             { title = "A full test guide"
             , slug = "a-guide"
-            , fullTextMarkdown = "# Some full test reource markdown"
+            , fullTextMarkdown = "# Some full test reource markdown\n\nA small paragraph."
             , maybeVideo =
                 Just
                     { title = "A guide video"
@@ -73,12 +73,13 @@ suite =
                         |> Query.contains
                             [ Html.h1 [] [ Html.text guideMinimal.title ]
                             ]
-            , test "Guide view has a body" <|
+            , test "Guide view has body that is HTML" <|
                 \() ->
-                    queryFromStyledHtml (view guideMinimal)
-                        |> Query.contains
-                            [ Html.p [] [ Html.text guideMinimal.fullTextMarkdown ]
-                            ]
+                    queryFromStyledHtml (view guideFull)
+                        |> Query.has
+                           [ tag "h1", text "Some full test reource markdown"
+                           , tag "p", text "A small paragraph."
+                           ]
             , test "Guide view can have a video" <|
                 \() ->
                     queryFromStyledHtml (view guideFull)
@@ -103,5 +104,7 @@ suite =
                                 , Html.li [] [ Html.a [ Html.Attributes.href "/another-guide" ] [ Html.text "Another related guide" ] ]
                                 ]
                             ]
+                           
             ]
+              
         ]


### PR DESCRIPTION
Fixes #85
Fixes #86 

## Description

- renders markdown in Guide records to HTML

I would prefer to work on the styling aspect of this issue when there are wireframes (or layout sketches) that cover the styling of the Guide Page view

@geeksforsocialchange/developers
