### PR TITLE
Story markdown rendering

### DIFF
--- a/src/Page/Stories/View.elm
+++ b/src/Page/Stories/View.elm
@@ -5,6 +5,7 @@ import Html.Styled.Attributes exposing (alt, href, src)
 import Message exposing (Msg)
 import Page.Shared.View
 import Page.Stories.Data
+import Theme.Markdown exposing (markdownToHtml)
 
 
 view : Page.Stories.Data.Story -> Html Msg
@@ -33,7 +34,7 @@ view story =
                 Nothing ->
                     [ text "" ]
             )
-        , p [] [ text story.fullTextMarkdown ]
+        , div [] (markdownToHtml story.fullTextMarkdown)
         , viewRelatedGuideTeasers story.relatedGuideList
         ]
 

--- a/tests/Stories.elm
+++ b/tests/Stories.elm
@@ -8,8 +8,8 @@ import Page.Stories.View exposing (view)
 import Svg.Styled exposing (metadata)
 import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
+import Test.Html.Selector exposing (tag, classes, text)
 import TestUtils exposing (queryFromStyledHtml)
-
 
 suite : Test
 suite =
@@ -28,7 +28,7 @@ suite =
         storyFull : Story
         storyFull =
             { title = "A full test story"
-            , fullTextMarkdown = "# Some full test reource markdown"
+            , fullTextMarkdown = "# Some full test reource markdown\n\nA small paragraph."
             , slug = "slug"
             , maybeLocation = Just "Test location"
             , maybeGroupOrIndividual = Just "Test group"
@@ -54,12 +54,13 @@ suite =
                         |> Query.contains
                             [ Html.h1 [] [ Html.text storyMinimal.title ]
                             ]
-            , test "Story view has a description" <|
+            , test "Story view has body that is HTML" <|
                 \() ->
-                    queryFromStyledHtml (view storyMinimal)
-                        |> Query.contains
-                            [ Html.p [] [ Html.text storyMinimal.fullTextMarkdown ]
-                            ]
+                    queryFromStyledHtml (view storyFull)
+                        |> Query.has
+                           [ tag "h1", text "Some full test reource markdown"
+                           , tag "p", text "A small paragraph."
+                           ]
             , test "Story view can have related guide teasers" <|
                 \() ->
                     queryFromStyledHtml (view storyFull)


### PR DESCRIPTION
Fixes #95 

## Description

Stories have their markdown rendered to HTML (and tests)

@geeksforsocialchange/developers
