### PR TITLE
Guides index list

### DIFF
--- a/src/I18n/Cy.elm
+++ b/src/I18n/Cy.elm
@@ -15,6 +15,9 @@ cyStrings key =
         GuideTitle ->
             "[cCc] Guide CY"
 
+        GuidesTitle ->
+            "[cCc] Guides CY"
+
         ChangeLanguage ->
             "[cCc] Switch to English"
 

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -18,6 +18,9 @@ enStrings key =
         GuideTitle ->
             "[cCc] Guide"
 
+        GuidesTitle ->
+            "[cCc] Guides"
+
         ---
         -- Header
         ---

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -6,6 +6,7 @@ type Key
       --- Page Titles
     | StoryTitle
     | GuideTitle
+    | GuidesTitle
     | ChangeLanguage
       --- 404 content
     | Story404Title

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -9,6 +9,7 @@ import Json.Decode
 import Message exposing (Msg(..))
 import Page.Guide.Data
 import Page.Guide.View
+import Page.Guides
 import Page.Index
 import Page.Shared.Data
 import Page.Stories.Data
@@ -115,4 +116,11 @@ view model =
                 { title = GuideTitle
                 , content =
                     Page.Guide.View.view (Page.Guide.Data.guideFromSlug model.language model.content.guides slug)
+                }
+
+        Guides ->
+            Theme.PageTemplate.view model
+                { title = GuidesTitle
+                , content =
+                    Page.Guides.view model
                 }

--- a/src/Page/Guides.elm
+++ b/src/Page/Guides.elm
@@ -1,0 +1,10 @@
+module Page.Guides exposing (view)
+
+import Html.Styled exposing (Html, div, text)
+import Message exposing (Msg)
+import Shared exposing (Model)
+
+
+view : Model -> Html Msg
+view _ =
+    div [] [ text "Guides index" ]

--- a/src/Page/Guides.elm
+++ b/src/Page/Guides.elm
@@ -1,10 +1,37 @@
 module Page.Guides exposing (view)
 
-import Html.Styled exposing (Html, div, text)
+import Dict
+import Html.Styled exposing (Html, a, div, h1, li, text, ul)
+import Html.Styled.Attributes exposing (class, href)
+import I18n.Keys exposing (Key(..))
+import I18n.Translate exposing (translate)
 import Message exposing (Msg)
+import Page.Guide.Data exposing (Guide)
+import Route
 import Shared exposing (Model)
 
 
 view : Model -> Html Msg
-view _ =
-    div [] [ text "Guides index" ]
+view model =
+    let
+        t =
+            translate model.language
+
+        guides =
+            List.map
+                guideCard
+                (List.sortBy
+                    .title
+                    (Dict.values model.content.guides)
+                )
+    in
+    div []
+        [ h1 [] [ text (t GuidesTitle) ]
+        , ul [] guides
+        ]
+
+
+guideCard : Guide -> Html Msg
+guideCard guide =
+    li [ class "guide-card" ]
+        [ a [ href (Route.toString (Route.Guide guide.slug)) ] [ text guide.title ] ]

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -1,4 +1,4 @@
-module Route exposing (Route(..), fromUrl)
+module Route exposing (Route(..), fromUrl, toString)
 
 import Url
 import Url.Parser as Parser exposing ((</>), Parser, map, oneOf, s, string, top)

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -8,6 +8,7 @@ type Route
     = Index
     | Story String
     | Guide String
+    | Guides
 
 
 fromUrl : Url.Url -> Maybe Route
@@ -28,6 +29,9 @@ toString route =
         Guide s ->
             "/guides" ++ "/" ++ s
 
+        Guides ->
+            "/guides"
+
 
 routeParser : Parser (Route -> a) a
 routeParser =
@@ -35,4 +39,5 @@ routeParser =
         [ map Index top
         , map Story (s "stories" </> string)
         , map Guide (s "guides" </> string)
+        , map Guides (s "guides")
         ]


### PR DESCRIPTION
Closes #60 

Guides are listed alphabetically when visiting `/guides`

It does not do the text free search of guides.

@geeksforsocialchange/developers
