### PR TITLE
Add ability to add pages in markdown

### DIFF
--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -1,0 +1,17 @@
+---
+title: About
+---
+
+## [cCc] Header
+
+#### [cCc] A subheader
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eu mollis urna, vel faucibus arcu. Vestibulum lacinia tortor dictum tempor dignissim. Donec lacus urna, varius non diam maximus, consequat faucibus augue. Morbi convallis sagittis enim, quis finibus libero interdum dapibus. Curabitur luctus mollis elit, sed molestie risus congue consectetur.
+
+Pellentesque egestas nec lacus ut sollicitudin. Fusce faucibus posuere lobortis. Integer rutrum dictum elementum. Donec id massa id odio convallis commodo. Suspendisse lorem augue, blandit quis lacinia eget, ullamcorper ornare nulla. Suspendisse ullamcorper eleifend pellentesque. Nulla aliquet hendrerit elementum. Maecenas tempor lorem vestibulum sollicitudin sollicitudin. Proin nisl enim, maximus et ex a, cursus malesuada orci. Sed ac pharetra dolor.
+
+#### Another subheader:
+
+Praesent at ex tellus. Proin libero odio, vehicula vel ultrices id, molestie vel nisl. Ut a elit sed tellus vehicula dictum at sit amet dui. Vivamus molestie molestie libero, et gravida sem molestie bibendum.
+
+Sed nec mollis metus, eu mattis nisl. Donec lacus felis, dictum in ornare ac, malesuada tincidunt eros. Praesent ac magna accumsan, egestas risus at, facilisis tellus.

--- a/elm.json
+++ b/elm.json
@@ -12,8 +12,7 @@
             "elm/json": "1.1.3",
             "elm/url": "1.0.0",
             "elm-community/json-extra": "4.3.0",
-            "rtfeldman/elm-css": "18.0.0",
-            "the-sett/elm-string-case": "1.0.2"
+            "rtfeldman/elm-css": "18.0.0"
         },
         "indirect": {
             "elm/html": "1.0.0",

--- a/elm.json
+++ b/elm.json
@@ -12,7 +12,8 @@
             "elm/json": "1.1.3",
             "elm/url": "1.0.0",
             "elm-community/json-extra": "4.3.0",
-            "rtfeldman/elm-css": "18.0.0"
+            "rtfeldman/elm-css": "18.0.0",
+            "the-sett/elm-string-case": "1.0.2"
         },
         "indirect": {
             "elm/html": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "npm run generate && vite build",
-    "generate": "npm run generate_guides && npm run generate_stories",
+    "generate": "npm run generate_guides && npm run generate_stories && npm run generate_pages",
+    "generate_pages": "m2j -o ./data/pages.json -c ./content/pages/*.md",
     "generate_guides": "m2j -o ./data/guides.json -c ./content/guides/*.md",
     "generate_stories": "m2j -o ./data/stories.json -c ./content/stories/*.md",
     "format": "elm-format src",

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -1,7 +1,6 @@
 module I18n.En exposing (enStrings)
 
 import I18n.Keys exposing (Key(..))
-import String.Case exposing (convertCase)
 
 
 enStrings : Key -> String
@@ -19,14 +18,11 @@ enStrings key =
         GuideTitle ->
             "[cCc] Guide"
 
-        PageTitle string ->
-            "[cCc]" ++ convertCase " " True False string
+        PageTitle title ->
+            "[cCc]" ++ title
 
         GuidesTitle ->
             "[cCc] Guides"
-
-        StoriesTitle ->
-            "[cCc] Stories"
 
         ---
         -- Header

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -1,6 +1,7 @@
 module I18n.En exposing (enStrings)
 
 import I18n.Keys exposing (Key(..))
+import String.Case exposing (convertCase)
 
 
 enStrings : Key -> String
@@ -17,6 +18,9 @@ enStrings key =
 
         GuideTitle ->
             "[cCc] Guide"
+
+        PageTitle string ->
+            "[cCc]" ++ convertCase " " True False string
 
         ---
         -- Header
@@ -40,6 +44,18 @@ enStrings key =
             "[cCc] Sorry, we can't find that story"
 
         Story404Body ->
+            "[cCc] Try searching again [home](\"\\\")"
+
+        Story404Slug ->
+            "story-not-found"
+
+        AncillaryPage404Title ->
+            "[cCc] Sorry, we can't find that page"
+
+        AncillaryPage404Slug ->
+            "page-not-found"
+
+        AncillaryPage404Body ->
             "[cCc] Try searching again [home](\"\\\")"
 
         ---

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -8,7 +8,6 @@ type Key
     | GuideTitle
     | PageTitle String
     | GuidesTitle
-    | StoriesTitle
     | ChangeLanguage
       --- 404 content
     | Story404Title

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -6,13 +6,18 @@ type Key
       --- Page Titles
     | StoryTitle
     | GuideTitle
+    | PageTitle String
     | ChangeLanguage
       --- 404 content
     | Story404Title
     | Story404Body
+    | Story404Slug
     | Guide404Title
     | Guide404Slug
     | Guide404Body
+    | AncillaryPage404Slug
+    | AncillaryPage404Title
+    | AncillaryPage404Body
       --- Footer
     | FooterProjectInfo
     | FooterTitleColumnA

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -7,12 +7,14 @@ import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..))
 import Json.Decode
 import Message exposing (Msg(..))
+import Page.Data
 import Page.Guide.Data
 import Page.Guide.View
 import Page.Index
 import Page.Shared.Data
 import Page.Stories.Data
 import Page.Stories.View
+import Page.View
 import Route exposing (Route(..))
 import Shared exposing (Model)
 import Theme.PageTemplate
@@ -110,9 +112,30 @@ view model =
                     Page.Stories.View.view (Page.Stories.Data.storyFromSlug model.language model.content.stories slug)
                 }
 
+        StoryIndex ->
+            Theme.PageTemplate.view model
+                { title = StoryTitle
+                , content =
+                    Page.Stories.View.view (Page.Stories.Data.storyFromSlug model.language model.content.stories "")
+                }
+
         Guide slug ->
             Theme.PageTemplate.view model
                 { title = GuideTitle
                 , content =
                     Page.Guide.View.view (Page.Guide.Data.guideFromSlug model.language model.content.guides slug)
+                }
+
+        GuideIndex ->
+            Theme.PageTemplate.view model
+                { title = GuideTitle
+                , content =
+                    Page.Guide.View.view (Page.Guide.Data.guideFromSlug model.language model.content.guides "")
+                }
+
+        Page slug ->
+            Theme.PageTemplate.view model
+                { title = PageTitle slug
+                , content =
+                    Page.View.view (Page.Data.pageFromSlug model.language model.content.pages slug)
                 }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -113,13 +113,6 @@ view model =
                     Page.Stories.View.view (Page.Stories.Data.storyFromSlug model.language model.content.stories slug)
                 }
 
-        Stories ->
-            Theme.PageTemplate.view model
-                { title = StoriesTitle
-                , content =
-                    Page.Stories.View.view (Page.Stories.Data.storyFromSlug model.language model.content.stories "")
-                }
-
         Guide slug ->
             Theme.PageTemplate.view model
                 { title = GuideTitle
@@ -136,7 +129,7 @@ view model =
 
         Page slug ->
             Theme.PageTemplate.view model
-                { title = PageTitle slug
+                { title = PageTitle (Page.Data.pageTitleFromSlug model.content.pages slug)
                 , content =
                     Page.View.view (Page.Data.pageFromSlug model.language model.content.pages slug)
                 }

--- a/src/Page/Data.elm
+++ b/src/Page/Data.elm
@@ -1,0 +1,50 @@
+module Page.Data exposing (Page, pageDictDecoder, pageFromSlug)
+
+import Dict exposing (Dict)
+import I18n.Keys exposing (Key(..))
+import I18n.Translate exposing (Language, translate)
+import Json.Decode
+import Json.Decode.Extra
+
+
+type alias Page =
+    { title : String
+    , slug : String
+    , fullTextMarkdown : String
+    }
+
+
+blankPage : Language -> Page
+blankPage language =
+    let
+        t : Key -> String
+        t =
+            translate language
+    in
+    { title = t AncillaryPage404Title
+    , slug = t AncillaryPage404Slug
+    , fullTextMarkdown = t AncillaryPage404Body
+    }
+
+
+pageDictDecoder : Json.Decode.Decoder (Dict String Page)
+pageDictDecoder =
+    Json.Decode.dict
+        (Json.Decode.succeed Page
+            |> Json.Decode.Extra.andMap
+                (Json.Decode.field "title" Json.Decode.string |> Json.Decode.Extra.withDefault "")
+            |> Json.Decode.Extra.andMap
+                (Json.Decode.field "basename" Json.Decode.string |> Json.Decode.Extra.withDefault "")
+            |> Json.Decode.Extra.andMap
+                (Json.Decode.field "content" Json.Decode.string |> Json.Decode.Extra.withDefault "")
+        )
+
+
+pageFromSlug : Language -> Dict String Page -> String -> Page
+pageFromSlug language pages slug =
+    case Dict.get slug pages of
+        Just aPage ->
+            aPage
+
+        Nothing ->
+            blankPage language

--- a/src/Page/Data.elm
+++ b/src/Page/Data.elm
@@ -1,4 +1,4 @@
-module Page.Data exposing (Page, pageDictDecoder, pageFromSlug)
+module Page.Data exposing (Page, pageDictDecoder, pageFromSlug, pageTitleFromSlug)
 
 import Dict exposing (Dict)
 import I18n.Keys exposing (Key(..))
@@ -48,3 +48,13 @@ pageFromSlug language pages slug =
 
         Nothing ->
             blankPage language
+
+
+pageTitleFromSlug : Dict String Page -> String -> String
+pageTitleFromSlug pages slug =
+    case Dict.get slug pages of
+        Just aPage ->
+            aPage.title
+
+        Nothing ->
+            ""

--- a/src/Page/Shared/Data.elm
+++ b/src/Page/Shared/Data.elm
@@ -2,12 +2,16 @@ module Page.Shared.Data exposing (Content, contentDictDecoder)
 
 import Dict exposing (Dict)
 import Json.Decode
+import Page.Data
 import Page.Guide.Data
 import Page.Stories.Data
 
 
 type alias Content =
-    { guides : Dict String Page.Guide.Data.Guide, stories : Dict String Page.Stories.Data.Story }
+    { guides : Dict String Page.Guide.Data.Guide
+    , stories : Dict String Page.Stories.Data.Story
+    , pages : Dict String Page.Data.Page
+    }
 
 
 contentDictDecoder : Json.Decode.Value -> Content
@@ -17,11 +21,15 @@ contentDictDecoder flags =
             goodContent
 
         Err _ ->
-            { guides = Dict.empty, stories = Dict.empty }
+            { guides = Dict.empty
+            , stories = Dict.empty
+            , pages = Dict.empty
+            }
 
 
 flagsDictDecoder : Json.Decode.Decoder Content
 flagsDictDecoder =
-    Json.Decode.map2 Content
+    Json.Decode.map3 Content
         (Json.Decode.field "guides" Page.Guide.Data.guideDictDecoder)
         (Json.Decode.field "stories" Page.Stories.Data.storyDictDecoder)
+        (Json.Decode.field "pages" Page.Data.pageDictDecoder)

--- a/src/Page/View.elm
+++ b/src/Page/View.elm
@@ -1,14 +1,16 @@
 module Page.View exposing (view)
 
 import Html.Styled exposing (Html, div, h1, text)
+import Html.Styled.Attributes exposing (css)
 import Message exposing (Msg)
 import Page.Data
+import Theme.Global exposing (centerContent)
 import Theme.Markdown exposing (markdownToHtml)
 
 
 view : Page.Data.Page -> Html Msg
 view page =
-    div []
+    div [ css [ centerContent ] ]
         [ h1 [] [ text page.title ]
         , div [] (markdownToHtml page.fullTextMarkdown)
         ]

--- a/src/Page/View.elm
+++ b/src/Page/View.elm
@@ -1,0 +1,14 @@
+module Page.View exposing (view)
+
+import Html.Styled exposing (Html, div, h1, text)
+import Message exposing (Msg)
+import Page.Data
+import Theme.Markdown exposing (markdownToHtml)
+
+
+view : Page.Data.Page -> Html Msg
+view page =
+    div []
+        [ h1 [] [ text page.title ]
+        , div [] (markdownToHtml page.fullTextMarkdown)
+        ]

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -7,7 +7,6 @@ import Url.Parser as Parser exposing ((</>), Parser, map, oneOf, s, string, top)
 type Route
     = Index
     | Story String
-    | Stories
     | Guide String
     | Guides
     | Page String
@@ -28,9 +27,6 @@ toString route =
         Story s ->
             "/stories" ++ "/" ++ s
 
-        Stories ->
-            "/guides"
-
         Guide s ->
             "/guides" ++ "/" ++ s
 
@@ -46,7 +42,6 @@ routeParser =
     oneOf
         [ map Index top
         , map Story (s "stories" </> string)
-        , map Stories (s "stories")
         , map Guide (s "guides" </> string)
         , map Guides (s "guides")
         , map Page string

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -7,7 +7,10 @@ import Url.Parser as Parser exposing ((</>), Parser, map, oneOf, s, string, top)
 type Route
     = Index
     | Story String
+    | StoryIndex
     | Guide String
+    | GuideIndex
+    | Page String
 
 
 fromUrl : Url.Url -> Maybe Route
@@ -25,8 +28,17 @@ toString route =
         Story s ->
             "/stories" ++ "/" ++ s
 
+        StoryIndex ->
+            "/stories"
+
         Guide s ->
             "/guides" ++ "/" ++ s
+
+        GuideIndex ->
+            "/guides"
+
+        Page s ->
+            "/" ++ s
 
 
 routeParser : Parser (Route -> a) a
@@ -34,5 +46,8 @@ routeParser =
     oneOf
         [ map Index top
         , map Story (s "stories" </> string)
+        , map StoryIndex (s "stories")
         , map Guide (s "guides" </> string)
+        , map GuideIndex (s "guides")
+        , map Page string
         ]

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -3,6 +3,7 @@ module Shared exposing (Content, Model)
 import Browser.Navigation
 import Dict exposing (Dict)
 import I18n.Translate exposing (Language)
+import Page.Data
 import Page.Guide.Data
 import Page.Stories.Data
 import Route exposing (Route)
@@ -17,4 +18,7 @@ type alias Model =
 
 
 type alias Content =
-    { guides : Dict String Page.Guide.Data.Guide, stories : Dict String Page.Stories.Data.Story }
+    { guides : Dict String Page.Guide.Data.Guide
+    , stories : Dict String Page.Stories.Data.Story
+    , pages : Dict String Page.Data.Page
+    }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -3,5 +3,6 @@ import { Elm } from "/src/Main.elm";
 
 import guides from "../../data/guides.json";
 import stories from "../../data/stories.json";
+import pages from "../../data/pages.json";
 
-const app = Elm.Main.init({ flags: { guides, stories } });
+const app = Elm.Main.init({ flags: { guides, stories, pages } });

--- a/tests/Page.elm
+++ b/tests/Page.elm
@@ -1,0 +1,44 @@
+module Page exposing (suite)
+
+import Html
+import I18n.Keys exposing (Key(..))
+import Page.Data
+import Page.View
+import Test exposing (Test, describe, test)
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
+import TestUtils exposing (queryFromStyledHtml)
+
+
+suite : Test
+suite =
+    let
+        page : Page.Data.Page
+        page =
+            { title = "A test page"
+            , slug = "a-page"
+            , fullTextMarkdown = "# Some markdown\n\nA small paragraph."
+            }
+
+        view =
+            Page.View.view
+    in
+    describe "Guide Page"
+        [ describe "View tests"
+            [ test "Page view has title" <|
+                \() ->
+                    queryFromStyledHtml (view page)
+                        |> Query.contains
+                            [ Html.h1 [] [ Html.text "A test page" ]
+                            ]
+            , test "Page view has body that is HTML" <|
+                \() ->
+                    queryFromStyledHtml (view page)
+                        |> Query.has
+                            [ Selector.tag "h1"
+                            , Selector.text "Some markdown"
+                            , Selector.tag "p"
+                            , Selector.text "A small paragraph."
+                            ]
+            ]
+        ]


### PR DESCRIPTION
Fixes #51 

## Description

- Allows any page in markdown to be added to `Pages` folder in the same manner as guides and stories
- Creates a title for the page from the page's slug (And adds a new elm package to help with string formatting for this)
- Adds tests to assert page is displaying as expected
- Routes correctly to a page once added, and also adds routing for stories index page in same manner as that for guides index, to avoid routing clashes

@geeksforsocialchange/developers

A question arose from this around page titles - I've opened up issue #99 to address this.