### PR TITLE
Feat/94 add google analytics and cookie banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,16 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite App</title>
+    <title>[cCc] Team Wilder Guides</title>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-D3VTD4SBDZ"></script>
+    <script type="module">
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+    </script>
+
     <script type="module" src="./src/js/index.js"></script>
   </head>
   <body></body>

--- a/index.html
+++ b/index.html
@@ -7,11 +7,16 @@
     <title>[cCc] Team Wilder Guides</title>
 
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-D3VTD4SBDZ"></script>
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-D3VTD4SBDZ"
+    ></script>
     <script type="module">
       window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
     </script>
 
     <script type="module" src="./src/js/index.js"></script>

--- a/src/CookieBanner.elm
+++ b/src/CookieBanner.elm
@@ -1,0 +1,44 @@
+port module CookieBanner exposing (saveConsent, viewCookieBanner)
+
+import Browser.Navigation exposing (back)
+import Html.Styled exposing (Html, button, div, h2, p, text)
+import Html.Styled.Events exposing (onClick)
+import I18n.Keys exposing (Key(..))
+import I18n.Translate exposing (Language, translate)
+import Message exposing (Msg(..))
+import Shared exposing (CookieState)
+
+
+viewCookieBanner : Language -> CookieState -> Html Msg
+viewCookieBanner language cookieState =
+    div []
+        [ if cookieState.cookieBannerIsOpen then
+            viewCookieBannerContent language cookieState
+
+          else
+            viewCookieSettingsButton language
+        ]
+
+
+viewCookieBannerContent : Language -> CookieState -> Html Msg
+viewCookieBannerContent language cookieState =
+    let
+        t : Key -> String
+        t =
+            translate language
+    in
+    div []
+        [ h2 [] [ text (t CookieBannerH2) ]
+        , p [] [ text (t CookieBannerP) ]
+        , button [ onClick CookiesDeclined ] [ text (t CookieDeclineButtonText) ]
+        , button [ onClick CookiesAccepted ] [ text (t CookieAcceptButtonText) ]
+        ]
+
+
+viewCookieSettingsButton : Language -> Html Msg
+viewCookieSettingsButton language =
+    button [ onClick CookieSettingsButtonClicked ]
+        [ text (translate language CookieSettingsButtonText) ]
+
+
+port saveConsent : Bool -> Cmd msg

--- a/src/CookieBanner.elm
+++ b/src/CookieBanner.elm
@@ -1,6 +1,5 @@
 port module CookieBanner exposing (saveConsent, viewCookieBanner)
 
-import Browser.Navigation exposing (back)
 import Html.Styled exposing (Html, button, div, h2, p, text)
 import Html.Styled.Events exposing (onClick)
 import I18n.Keys exposing (Key(..))
@@ -13,15 +12,15 @@ viewCookieBanner : Language -> CookieState -> Html Msg
 viewCookieBanner language cookieState =
     div []
         [ if cookieState.cookieBannerIsOpen then
-            viewCookieBannerContent language cookieState
+            viewCookieBannerContent language
 
           else
             viewCookieSettingsButton language
         ]
 
 
-viewCookieBannerContent : Language -> CookieState -> Html Msg
-viewCookieBannerContent language cookieState =
+viewCookieBannerContent : Language -> Html Msg
+viewCookieBannerContent language =
     let
         t : Key -> String
         t =

--- a/src/GoogleAnalytics.elm
+++ b/src/GoogleAnalytics.elm
@@ -1,20 +1,10 @@
 port module GoogleAnalytics exposing (updateAnalytics, updateAnalyticsEvent, updateAnalyticsPage)
 
--- js ports can only take one argument, so bundle event strings
-
 
 type alias GaEvent =
     { category : String
     , action : String
     , label : String
-    }
-
-
-gaEvent : String -> String -> String -> GaEvent
-gaEvent category action label =
-    { category = category
-    , action = action
-    , label = label
     }
 
 

--- a/src/GoogleAnalytics.elm
+++ b/src/GoogleAnalytics.elm
@@ -1,0 +1,33 @@
+port module GoogleAnalytics exposing (updateAnalytics, updateAnalyticsEvent, updateAnalyticsPage)
+
+-- js ports can only take one argument, so bundle event strings
+
+
+type alias GaEvent =
+    { category : String
+    , action : String
+    , label : String
+    }
+
+
+gaEvent : String -> String -> String -> GaEvent
+gaEvent category action label =
+    { category = category
+    , action = action
+    , label = label
+    }
+
+
+updateAnalytics : Bool -> Cmd msg -> Cmd msg
+updateAnalytics hasConsented sendAnalyticsMessage =
+    if hasConsented then
+        sendAnalyticsMessage
+
+    else
+        Cmd.none
+
+
+port updateAnalyticsPage : String -> Cmd msg
+
+
+port updateAnalyticsEvent : GaEvent -> Cmd msg

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -79,7 +79,7 @@ enStrings key =
 
         CookieBannerP ->
             """
-            Our website uses cookies and data to make sure you have the best experience and to help us fundraise efficiently to save wildlife. Some cookies are essential to make our website work.
+            [cCc] Our website uses cookies and data to make sure you have the best experience and to help us fundraise efficiently to save wildlife. Some cookies are essential to make our website work.
             """
 
         CookieAcceptButtonText ->

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -72,6 +72,26 @@ enStrings key =
             "https://www.wildlifetrusts.org/wildlife-trusts"
 
         ---
+        -- Cookie banner
+        ---
+        CookieBannerH2 ->
+            "Are you ok to proceed with all cookies and data?"
+
+        CookieBannerP ->
+            """
+            Our website uses cookies and data to make sure you have the best experience and to help us fundraise efficiently to save wildlife. Some cookies are essential to make our website work.
+            """
+
+        CookieAcceptButtonText ->
+            "Okay, got it"
+
+        CookieDeclineButtonText ->
+            "No thanks"
+
+        CookieSettingsButtonText ->
+            "Cookie settings"
+
+        ---
         -- Index page
         ---
         WelcomeP1 ->

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -22,6 +22,12 @@ type Key
     | FooterVisitWebsiteLink
     | FooterFindYourLocalTrustText
     | FooterFindYourLocalTrustLink
+      --- Cookie banner
+    | CookieBannerH2
+    | CookieBannerP
+    | CookieAcceptButtonText
+    | CookieDeclineButtonText
+    | CookieSettingsButtonText
       --- Index Page
     | WelcomeP1
     | WelcomeP2

--- a/src/I18n/Translate.elm
+++ b/src/I18n/Translate.elm
@@ -1,4 +1,4 @@
-module I18n.Translate exposing (Language(..), translate)
+module I18n.Translate exposing (Language(..), languageToString, translate)
 
 import I18n.Cy exposing (cyStrings)
 import I18n.En exposing (enStrings)
@@ -8,6 +8,16 @@ import I18n.Keys exposing (Key)
 type Language
     = English
     | Welsh
+
+
+languageToString : Language -> String
+languageToString language =
+    case language of
+        English ->
+            "English"
+
+        Welsh ->
+            "Welsh"
 
 
 translate : Language -> Key -> String

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -44,24 +44,19 @@ init flags url key =
         maybeRoute =
             Route.fromUrl url
 
+        storedConsent : String
         storedConsent =
             consentDecoder flags
 
+        hasConsented : Bool
         hasConsented =
-            if storedConsent == "true" then
-                True
+            -- for null, false & undefined, we assume no consent
+            storedConsent == "true"
 
-            else
-                -- for null, false & undefined, we assume no consent
-                False
-
+        showCookieBanner : Bool
         showCookieBanner =
-            if storedConsent == "null" then
-                True
-
-            else
-                -- user has previously stated a preference, info should be collapsed
-                False
+            -- user has previously stated a preference, info should be collapsed
+            storedConsent == "null"
     in
     ( { key = key
       , page = Maybe.withDefault Index maybeRoute
@@ -76,6 +71,7 @@ init flags url key =
     )
 
 
+consentDecoder : Flags -> String
 consentDecoder flags =
     case Json.Decode.decodeValue flagsConsentDecoder flags of
         Ok goodConsentedBool ->
@@ -85,6 +81,7 @@ consentDecoder flags =
             "null"
 
 
+flagsConsentDecoder : Json.Decode.Decoder String
 flagsConsentDecoder =
     Json.Decode.field "hasConsented" Json.Decode.string
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -14,7 +14,7 @@ import Page.Shared.Data
 import Page.Stories.Data
 import Page.Stories.View
 import Route exposing (Route(..))
-import Shared exposing (Model)
+import Shared exposing (CookieState, Model)
 import Theme.PageTemplate
 import Url
 
@@ -44,7 +44,10 @@ init flags url key =
     in
     ( { key = key
       , page = Maybe.withDefault Index maybeRoute
-      , enableAnalytics = False
+      , cookieState =
+            { enableAnalytics = False
+            , cookieBannerIsOpen = True
+            }
       , content = Page.Shared.Data.contentDictDecoder flags
       , language = English
       }
@@ -87,7 +90,15 @@ update msg model =
             )
 
         CookiesAccepted ->
-            ( { model | enableAnalytics = True }, Cmd.none )
+            ( { model | cookieState = updateCookieState model.cookieState True }, Cmd.none )
+
+        CookiesDeclined ->
+            ( { model | cookieState = updateCookieState model.cookieState False }, Cmd.none )
+
+
+updateCookieState : CookieState -> Bool -> CookieState
+updateCookieState oldState optedIn =
+    { oldState | enableAnalytics = optedIn, cookieBannerIsOpen = False }
 
 
 subscriptions : Model -> Sub Msg

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -89,11 +89,19 @@ update msg model =
             , Cmd.none
             )
 
+        CookieSettingsButtonClicked ->
+            ( { model | cookieState = openCookieBanner model.cookieState }, Cmd.none )
+
         CookiesAccepted ->
             ( { model | cookieState = updateCookieState model.cookieState True }, Cmd.none )
 
         CookiesDeclined ->
             ( { model | cookieState = updateCookieState model.cookieState False }, Cmd.none )
+
+
+openCookieBanner : CookieState -> CookieState
+openCookieBanner oldState =
+    { oldState | cookieBannerIsOpen = True }
 
 
 updateCookieState : CookieState -> Bool -> CookieState

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -44,6 +44,7 @@ init flags url key =
     in
     ( { key = key
       , page = Maybe.withDefault Index maybeRoute
+      , enableAnalytics = False
       , content = Page.Shared.Data.contentDictDecoder flags
       , language = English
       }
@@ -84,6 +85,9 @@ update msg model =
                 { model | language = English }
             , Cmd.none
             )
+
+        CookiesAccepted ->
+            ( { model | enableAnalytics = True }, Cmd.none )
 
 
 subscriptions : Model -> Sub Msg

--- a/src/Message.elm
+++ b/src/Message.elm
@@ -8,5 +8,6 @@ type Msg
     = UrlChanged Url.Url
     | LinkClicked Browser.UrlRequest
     | LanguageChangeRequested
+    | CookieSettingsButtonClicked
     | CookiesAccepted
     | CookiesDeclined

--- a/src/Message.elm
+++ b/src/Message.elm
@@ -8,3 +8,4 @@ type Msg
     = UrlChanged Url.Url
     | LinkClicked Browser.UrlRequest
     | LanguageChangeRequested
+    | CookiesAccepted

--- a/src/Message.elm
+++ b/src/Message.elm
@@ -9,3 +9,4 @@ type Msg
     | LinkClicked Browser.UrlRequest
     | LanguageChangeRequested
     | CookiesAccepted
+    | CookiesDeclined

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -1,4 +1,4 @@
-module Route exposing (Route(..), fromUrl)
+module Route exposing (Route(..), fromUrl, toString)
 
 import Url
 import Url.Parser as Parser exposing ((</>), Parser, map, oneOf, s, string, top)

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -10,6 +10,7 @@ import Route exposing (Route)
 type alias Model =
     { key : Browser.Navigation.Key
     , page : Route
+    , enableAnalytics : Bool
     , language : Language
     , content : Content
     }

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -1,4 +1,4 @@
-module Shared exposing (Content, Model)
+module Shared exposing (Content, CookieState, Model)
 
 import Browser.Navigation
 import Dict exposing (Dict)
@@ -11,11 +11,19 @@ import Route exposing (Route)
 type alias Model =
     { key : Browser.Navigation.Key
     , page : Route
-    , enableAnalytics : Bool
+    , cookieState : CookieState
     , language : Language
     , content : Content
     }
 
 
+type alias CookieState =
+    { enableAnalytics : Bool
+    , cookieBannerIsOpen : Bool
+    }
+
+
 type alias Content =
-    { guides : Dict String Page.Guide.Data.Guide, stories : Dict String Page.Stories.Data.Story }
+    { guides : Dict String Page.Guide.Data.Guide
+    , stories : Dict String Page.Stories.Data.Story
+    }

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -1,5 +1,6 @@
 module Theme.PageTemplate exposing (PageInfo, view)
 
+import CookieBanner
 import Css exposing (Style, alignItems, auto, batch, center, column, displayFlex, flex2, flexBasis, flexDirection, height, int, minHeight, pct, vh)
 import Html.Styled exposing (Html, button, div, main_, text)
 import Html.Styled.Attributes exposing (css)
@@ -34,6 +35,7 @@ view model pageInfo =
                 ]
             ]
         , FooterTemplate.view model.language
+        , CookieBanner.viewCookieBanner model.language model.cookieState
         ]
 
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -4,4 +4,34 @@ import { Elm } from "/src/Main.elm";
 import guides from "../../data/guides.json";
 import stories from "../../data/stories.json";
 
-const app = Elm.Main.init({ flags: { guides, stories } });
+const hasConsented = sessionStorage.getItem("ga-cookie-consent") ? sessionStorage.getItem("ga-cookie-consent") : "null";
+
+const app = Elm.Main.init({ flags: { hasConsented, guides, stories } });
+
+app.ports.saveConsent.subscribe(function (hasConsented) {
+  // User will have to re-consent every time browser is closed, but not on refresh.
+  sessionStorage.setItem("ga-cookie-consent", hasConsented);
+});
+
+// Google analytics subscribe to page changes and custom events
+app.ports.updateAnalyticsPage.subscribe(function (page) {
+    if (typeof window != undefined) {
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      // TODO this is temporarily @katjam dev account
+      gtag("config", "G-D3VTD4SBDZ", { "page_path" : page });
+    }
+});
+
+app.ports.updateAnalyticsEvent.subscribe(function (gaEvent) {
+  if (typeof window != undefined) {
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag("event", gaEvent.action, { "event_category" : gaEvent.category, "event_label" : gaEvent.label });
+  }
+});
+

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -4,7 +4,9 @@ import { Elm } from "/src/Main.elm";
 import guides from "../../data/guides.json";
 import stories from "../../data/stories.json";
 
-const hasConsented = sessionStorage.getItem("ga-cookie-consent") ? sessionStorage.getItem("ga-cookie-consent") : "null";
+const hasConsented = sessionStorage.getItem("ga-cookie-consent")
+  ? sessionStorage.getItem("ga-cookie-consent")
+  : "null";
 
 const app = Elm.Main.init({ flags: { hasConsented, guides, stories } });
 
@@ -15,23 +17,29 @@ app.ports.saveConsent.subscribe(function (hasConsented) {
 
 // Google analytics subscribe to page changes and custom events
 app.ports.updateAnalyticsPage.subscribe(function (page) {
-    if (typeof window != undefined) {
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      // TODO this is temporarily @katjam dev account
-      gtag("config", "G-D3VTD4SBDZ", { "page_path" : page });
+  if (typeof window != undefined) {
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
     }
+    gtag("js", new Date());
+
+    // TODO this is temporarily @katjam dev account
+    gtag("config", "G-D3VTD4SBDZ", { page_path: page });
+  }
 });
 
 app.ports.updateAnalyticsEvent.subscribe(function (gaEvent) {
   if (typeof window != undefined) {
     window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag("js", new Date());
 
-    gtag("event", gaEvent.action, { "event_category" : gaEvent.category, "event_label" : gaEvent.label });
+    gtag("event", gaEvent.action, {
+      event_category: gaEvent.category,
+      event_label: gaEvent.label,
+    });
   }
 });
-


### PR DESCRIPTION
Fixes #94 

## Description

- Add some Google analytics boilerplate with cookie banner

NOTES:
- Note currently wired up to Katja dev GA account
- Need to confirm analytics are respecting the opt in and out
- Currently the analytics will not fire if opted out, but might also be able to prevent initial tag registering before consent given.

@geeksforsocialchange/developers
