### PR TITLE
Refactored view title rendering

### DIFF
--- a/src/I18n/Cy.elm
+++ b/src/I18n/Cy.elm
@@ -9,12 +9,6 @@ cyStrings key =
         SiteTitle ->
             "[cCc] Team Wilder CY"
 
-        StoryTitle ->
-            "[cCc] Story CY"
-
-        GuideTitle ->
-            "[cCc] Guide CY"
-
         GuidesTitle ->
             "[cCc] Guides CY"
 

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -12,15 +12,6 @@ enStrings key =
         SiteTitle ->
             "[cCc] Team Wilder"
 
-        StoryTitle ->
-            "[cCc] Story"
-
-        GuideTitle ->
-            "[cCc] Guide"
-
-        PageTitle title ->
-            "[cCc]" ++ title
-
         GuidesTitle ->
             "[cCc] Guides"
 

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -4,9 +4,6 @@ module I18n.Keys exposing (Key(..))
 type Key
     = SiteTitle
       --- Page Titles
-    | StoryTitle
-    | GuideTitle
-    | PageTitle String
     | GuidesTitle
     | ChangeLanguage
       --- 404 content

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -176,33 +176,28 @@ view : Model -> Html Msg
 view model =
     case model.page of
         Index ->
-            Theme.PageTemplate.view model
-                { title = SiteTitle, content = Page.Index.view model }
+            Theme.PageTemplate.view model (Page.Index.view model)
 
         Story slug ->
-            Theme.PageTemplate.view model
-                { title = StoryTitle
-                , content =
-                    Page.Story.View.view (Page.Story.Data.storyFromSlug model.language model.content.stories slug)
-                }
+            let
+                story =
+                    Page.Story.Data.storyFromSlug model.language model.content.stories slug
+            in
+            Theme.PageTemplate.view model (Page.Story.View.view story)
 
         Guide slug ->
-            Theme.PageTemplate.view model
-                { title = GuideTitle
-                , content =
-                    Page.Guide.View.view (Page.Guide.Data.guideFromSlug model.language model.content.guides slug)
-                }
+            let
+                guide =
+                    Page.Guide.Data.guideFromSlug model.language model.content.guides slug
+            in
+            Theme.PageTemplate.view model (Page.Guide.View.view guide)
 
         Guides ->
-            Theme.PageTemplate.view model
-                { title = GuidesTitle
-                , content =
-                    Page.Guides.view model
-                }
+            Theme.PageTemplate.view model (Page.Guides.view model)
 
         Page slug ->
-            Theme.PageTemplate.view model
-                { title = PageTitle (Page.Data.pageTitleFromSlug model.content.pages slug)
-                , content =
-                    Page.View.view (Page.Data.pageFromSlug model.language model.content.pages slug)
-                }
+            let
+                page =
+                    Page.Data.pageFromSlug model.language model.content.pages slug
+            in
+            Theme.PageTemplate.view model (Page.View.view page)

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -1,4 +1,4 @@
-module Theme.PageTemplate exposing (PageInfo, view)
+module Theme.PageTemplate exposing (view)
 
 import CookieBanner
 import Css exposing (Style, alignItems, auto, batch, center, column, displayFlex, flex2, flexBasis, flexDirection, height, int, minHeight, pct, vh)
@@ -10,15 +10,10 @@ import I18n.Translate exposing (translate)
 import Message exposing (Msg(..))
 import Shared exposing (Model)
 import Theme.FooterTemplate as FooterTemplate
-import Theme.HeaderTemplate as HeaderTemplate
 
 
-type alias PageInfo =
-    { title : Key, content : Html Msg }
-
-
-view : Model -> PageInfo -> Html Msg
-view model pageInfo =
+view : Model -> Html Msg -> Html Msg
+view model content =
     let
         t : Key -> String
         t =
@@ -26,11 +21,10 @@ view model pageInfo =
     in
     div [ css [ pageWrapperStyle ] ]
         [ div [ css [ pageStyle ] ]
-            [ HeaderTemplate.view { content = t pageInfo.title }
-            , main_ [ css [ mainStyle ] ]
+            [ main_ [ css [ mainStyle ] ]
                 [ button [ onClick LanguageChangeRequested ] [ text (t ChangeLanguage) ]
                 , div []
-                    [ pageInfo.content
+                    [ content
                     ]
                 ]
             ]


### PR DESCRIPTION
Fixes #99

## Description

- Only one `<h1>` on a page
- `<h1>` is defined in view, not in header
- content (guide/story/page) has title come from markdown

@geeksforsocialchange/developers
