### PR TITLE
Use design colors

### DIFF
--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -56,7 +56,8 @@ viewRelatedGuideTeasers guideList =
     else
         text ""
 
-guideTitle: List Style
+
+guideTitle : List Style
 guideTitle =
     [ fontFamilies [ "Ludicrous", "serif" ]
     ]

--- a/src/Theme/FooterTemplate.elm
+++ b/src/Theme/FooterTemplate.elm
@@ -1,10 +1,11 @@
 module Theme.FooterTemplate exposing (view)
 
-import Css exposing (Style, batch, column, displayFlex, em, fitContent, flexDirection, flexShrink, flexWrap, justifyContent, margin2, minHeight, pct, row, spaceAround, width, wrap, zero)
+import Css exposing (Style, backgroundColor, batch, column, displayFlex, em, fitContent, flexDirection, flexShrink, flexWrap, justifyContent, margin2, minHeight, pct, row, spaceAround, width, wrap, zero)
 import Html.Styled exposing (Html, a, div, footer, h3, img, p, text)
 import Html.Styled.Attributes exposing (css, href, src)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language, translate)
+import Theme.Global exposing (lightTeal, purple, teal)
 
 
 view : Language -> Html msg
@@ -80,6 +81,7 @@ footerContainerStyle =
         , flexWrap wrap
         , justifyContent spaceAround
         , minHeight fitContent
+        , backgroundColor lightTeal
         ]
 
 

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,6 +1,6 @@
-module Theme.Global exposing (centerContent, globalStyles)
+module Theme.Global exposing (centerContent, globalStyles, lightTeal, purple, teal)
 
-import Css exposing (Style, absolute, alignItems, auto, batch, boxSizing, center, ch, column, contentBox, displayFlex, flexDirection, fontFamilies, height, hidden, left, marginLeft, marginRight, maxWidth, overflow, position, px, top, width)
+import Css exposing (Color, Style, absolute, alignItems, auto, batch, boxSizing, center, ch, column, contentBox, displayFlex, flexDirection, fontFamilies, height, hex, hidden, left, marginLeft, marginRight, maxWidth, overflow, position, px, top, width)
 import Css.Global exposing (global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html)
@@ -75,6 +75,24 @@ withMediaMediumDesktopUp =
 -- Brand colours
 -- Accent colours
 -- Text and background colours
+
+
+purple : Color
+purple =
+    hex "54257F"
+
+
+teal : Color
+teal =
+    hex "058295"
+
+
+lightTeal : Color
+lightTeal =
+    hex "e7f2f4"
+
+
+
 -- Transitions
 -- Buttons (components)
 -- Buttons (styles)

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,6 +1,6 @@
 module Theme.Global exposing (centerContent, globalStyles, lightTeal, purple, teal)
 
-import Css exposing (Color, Style, absolute, alignItems, auto, batch, boxSizing, center, ch, column, contentBox, displayFlex, flexDirection, fontFamilies, height, hex, hidden, left, marginLeft, marginRight, maxWidth, overflow, position, px, top, width)
+import Css exposing (Color, Style, absolute, alignItems, auto, batch, boxSizing, center, ch, color, column, contentBox, displayFlex, flexDirection, fontFamilies, height, hex, hidden, left, margin, marginLeft, marginRight, maxWidth, overflow, position, px, top, width, zero)
 import Css.Global exposing (global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html)
@@ -111,15 +111,28 @@ globalStyles : Html msg
 globalStyles =
     global
         [ typeSelector "body"
-            [ fontFamilies [ "Rubik", "sans-serif" ] ]
+            [ fontFamilies [ "Rubik", "sans-serif" ]
+            , margin zero
+            ]
         , typeSelector "h1"
-            [ fontFamilies [ "Adelle", "serif" ] ]
+            [ fontFamilies [ "Adelle", "serif" ]
+            , color purple
+            ]
         , typeSelector "h2"
-            []
+            [ fontFamilies [ "Adelle", "serif" ]
+            , color purple
+            ]
         , typeSelector "h3"
-            []
+            [ fontFamilies [ "Adelle", "serif" ]
+            , color purple
+            ]
         , typeSelector "h4"
-            []
+            [ fontFamilies [ "Adelle", "serif" ]
+            , color purple
+            ]
+        , typeSelector "a"
+            [ color purple
+            ]
         , typeSelector "b"
             []
         , typeSelector "p"

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -1,7 +1,7 @@
 module Theme.PageTemplate exposing (view)
 
 import CookieBanner
-import Css exposing (Style, alignItems, auto, batch, center, column, displayFlex, flex2, flexBasis, flexDirection, height, int, minHeight, pct, vh)
+import Css exposing (Style, alignItems, auto, backgroundColor, batch, center, column, displayFlex, flex2, flexBasis, flexDirection, height, int, minHeight, pct, vh)
 import Html.Styled exposing (Html, button, div, main_, text)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)
@@ -10,7 +10,7 @@ import I18n.Translate exposing (translate)
 import Message exposing (Msg(..))
 import Shared exposing (Model)
 import Theme.FooterTemplate as FooterTemplate
-import Theme.Global exposing (globalStyles)
+import Theme.Global exposing (globalStyles, lightTeal, purple, teal)
 import Theme.HeaderTemplate as HeaderTemplate
 
 
@@ -43,7 +43,8 @@ view model content =
 mainStyle : Style
 mainStyle =
     batch
-        []
+        [ backgroundColor lightTeal
+        ]
 
 
 pageStyle : Style
@@ -60,4 +61,5 @@ pageWrapperStyle =
         , flexDirection column
         , height (pct 100)
         , minHeight (vh 100)
+        , backgroundColor teal
         ]


### PR DESCRIPTION
Fixes #110 

## Description

- Colors are defined in global theme module
- Page background is teal, content background is light teal (as per design)
- Content headers/anchors are purple.

Not covered:
- footer logo area (depends on PR #137)

@geeksforsocialchange/developers
