### PR TITLE
Responsive layout containers for home page, guide & story pages

### DIFF
--- a/content/guides/en/types-of-community-group.md
+++ b/content/guides/en/types-of-community-group.md
@@ -7,6 +7,16 @@ summary: |-
   If you’re just a small group of volunteers, with no plans to employ staff or rent premises, this is the one for you.
 
   It’s the easiest group to set up. All you need is to write a **constitution** or **governing document**. This is a list of rules for the group. It also says what your group’s going to do, and how it’s going to do it.
+relatedGuides:
+  - title: "Types of Community Group"
+    slug: types-of-community-group
+relatedStories:
+  - title: "[cCc] Dummy story"
+    slug: "story-slug"
+    image:
+      src: "/images/wildlife-trust-logo.png"
+      alt: "Wildlife Trusts logo"
+    description: "A short description of my story"
 ---
 
 ## [cCc] Types of Community Group (England and Wales)

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -123,3 +123,6 @@ enStrings key =
 
         WelcomeP3 ->
             "[cCc] The goal of Nextdoor Nature is to get at least 1 in 4 people across the UK taking Action for Nature. This online library aims to support anyone who is interested in finding out what they can do, and how they can get other people involved."
+
+        ExploreGuidesListPlaceholder ->
+            "[cCc] Explore guides by theme"

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -39,3 +39,4 @@ type Key
     | WelcomeP1
     | WelcomeP2
     | WelcomeP3
+    | ExploreGuidesListPlaceholder

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -1,13 +1,13 @@
 module Page.Guide.View exposing (view)
 
-import Css exposing (Style, batch, fontFamilies)
-import Html.Styled exposing (Html, a, div, h1, li, p, text, ul)
+import Css exposing (Style, fontFamilies)
+import Html.Styled exposing (Html, a, div, h1, li, text, ul)
 import Html.Styled.Attributes exposing (css, href)
 import Message exposing (Msg)
 import Page.Guide.Data
 import Page.GuideTeaser
 import Page.Shared.View
-import Theme.Global exposing (centerContent)
+import Theme.Global exposing (centerContent, pageColumnBlockStyle, pageColumnStyle, pageWrapperStyle, topTwoColumnsWrapperStyle)
 import Theme.Markdown exposing (markdownToHtml)
 
 
@@ -15,11 +15,18 @@ view : Page.Guide.Data.Guide -> Html Msg
 view guide =
     div [ css [ centerContent ] ]
         [ h1 [ css guideTitle ] [ text guide.title ]
-        , div [] (markdownToHtml guide.fullTextMarkdown)
-        , viewMaybeVideo guide.maybeVideo
-        , viewMaybeAudio guide.maybeAudio
-        , Page.Shared.View.viewStoryTeasers guide.relatedStoryList
-        , viewRelatedGuideTeasers guide.relatedGuideList
+        , div [ css [ pageWrapperStyle ] ]
+            [ div [ css [ topTwoColumnsWrapperStyle ] ]
+                [ div [ css [ pageColumnStyle ] ]
+                    [ div [ css [ pageColumnBlockStyle ] ] (markdownToHtml guide.fullTextMarkdown) ]
+                , viewMaybeVideo guide.maybeVideo
+                , viewMaybeAudio guide.maybeAudio
+                ]
+            , div [ css [ pageColumnStyle ] ]
+                [ Page.Shared.View.viewStoryTeasers guide.relatedStoryList
+                , viewRelatedGuideTeasers guide.relatedGuideList
+                ]
+            ]
         ]
 
 
@@ -27,7 +34,9 @@ viewMaybeVideo : Maybe Page.Shared.View.VideoMeta -> Html Msg
 viewMaybeVideo maybeVideoMeta =
     case maybeVideoMeta of
         Just aVideo ->
-            Page.Shared.View.viewVideo aVideo
+            div [ css [ pageColumnStyle ] ]
+                [ Page.Shared.View.viewVideo aVideo
+                ]
 
         Nothing ->
             text ""
@@ -37,7 +46,9 @@ viewMaybeAudio : Maybe Page.Shared.View.AudioMeta -> Html Msg
 viewMaybeAudio maybeAudioMeta =
     case maybeAudioMeta of
         Just anAudio ->
-            Page.Shared.View.viewAudio anAudio
+            div [ css [ pageColumnStyle ] ]
+                [ Page.Shared.View.viewAudio anAudio
+                ]
 
         Nothing ->
             text ""

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -21,19 +21,23 @@ view model =
         [ div [ css [ pageWrapperStyle ] ]
             [ div [ css [ topTwoColumnsWrapperStyle ] ]
                 [ div [ css [ pageColumnStyle ] ]
-                    [ p [ css [ pageColumnBlockStyle ] ] [ text (t WelcomeP1) ]
-                    , p [ css [ pageColumnBlockStyle ] ] [ text (t WelcomeP2) ]
-                    , p [ css [ pageColumnBlockStyle ] ] [ text (t WelcomeP3) ]
-                    ]
+                    (viewTextColumn t [ WelcomeP1, WelcomeP2, WelcomeP3 ])
                 , div [ css [ pageColumnStyle ] ]
                     [ Page.Guide.Data.teaserListFromGuideDict model.language model.content.guides
                         |> Page.Shared.View.viewGuideTeaserList
                     ]
                 ]
             , div [ css [ pageColumnStyle ] ]
-                [ p [ css [ pageColumnBlockStyle ] ] [ text (t ExploreGuidesListPlaceholder) ]
-                , p [ css [ pageColumnBlockStyle ] ] [ text (t ExploreGuidesListPlaceholder) ]
-                , p [ css [ pageColumnBlockStyle ] ] [ text (t ExploreGuidesListPlaceholder) ]
-                ]
+                (viewTextColumn t
+                    [ ExploreGuidesListPlaceholder
+                    , ExploreGuidesListPlaceholder
+                    , ExploreGuidesListPlaceholder
+                    ]
+                )
             ]
         ]
+
+
+viewTextColumn : (Key -> String) -> List Key -> List (Html msg)
+viewTextColumn t paragraphs =
+    List.map (\para -> p [ css [ pageColumnBlockStyle ] ] [ text (t para) ]) paragraphs

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -8,7 +8,7 @@ import Message exposing (Msg)
 import Page.Guide.Data
 import Page.Shared.View
 import Shared exposing (Model)
-import Theme.Global exposing (centerContent)
+import Theme.Global exposing (centerContent, pageColumnBlockStyle, pageColumnStyle, pageWrapperStyle, topTwoColumnsWrapperStyle)
 
 
 view : Model -> Html Msg
@@ -18,9 +18,22 @@ view model =
             translate model.language
     in
     div [ css [ centerContent ] ]
-        [ p [] [ text (t WelcomeP1) ]
-        , p [] [ text (t WelcomeP2) ]
-        , p [] [ text (t WelcomeP3) ]
-        , Page.Guide.Data.teaserListFromGuideDict model.language model.content.guides
-            |> Page.Shared.View.viewGuideTeaserList
+        [ div [ css [ pageWrapperStyle ] ]
+            [ div [ css [ topTwoColumnsWrapperStyle ] ]
+                [ div [ css [ pageColumnStyle ] ]
+                    [ p [ css [ pageColumnBlockStyle ] ] [ text (t WelcomeP1) ]
+                    , p [ css [ pageColumnBlockStyle ] ] [ text (t WelcomeP2) ]
+                    , p [ css [ pageColumnBlockStyle ] ] [ text (t WelcomeP3) ]
+                    ]
+                , div [ css [ pageColumnStyle ] ]
+                    [ Page.Guide.Data.teaserListFromGuideDict model.language model.content.guides
+                        |> Page.Shared.View.viewGuideTeaserList
+                    ]
+                ]
+            , div [ css [ pageColumnStyle ] ]
+                [ p [ css [ pageColumnBlockStyle ] ] [ text (t ExploreGuidesListPlaceholder) ]
+                , p [ css [ pageColumnBlockStyle ] ] [ text (t ExploreGuidesListPlaceholder) ]
+                , p [ css [ pageColumnBlockStyle ] ] [ text (t ExploreGuidesListPlaceholder) ]
+                ]
+            ]
         ]

--- a/src/Page/Shared/View.elm
+++ b/src/Page/Shared/View.elm
@@ -9,6 +9,7 @@ import Message exposing (Msg)
 import Page.GuideTeaser
 import String exposing (length, padRight)
 import Svg.Styled exposing (image)
+import Theme.Global exposing (teaserImageStyle)
 
 
 type alias AudioMeta =
@@ -95,6 +96,7 @@ viewVideo videoMeta =
             , attribute "allowfullscreen" "true"
             , autoplay False
             , title videoMeta.title
+            , css [ Theme.Global.embeddedVideoStyle ]
             ]
             []
         ]
@@ -102,7 +104,10 @@ viewVideo videoMeta =
 
 viewAudio : AudioMeta -> Html Msg
 viewAudio audioMeta =
-    text "[fFf] render audio player"
+    div
+        [ css [ Theme.Global.embeddedVideoStyle ]
+        ]
+        [ text "[fFf] render audio player" ]
 
 
 limitContent : String -> Int -> String
@@ -136,7 +141,7 @@ viewGuideTeaser teaser =
                     defaultTeaserImg
     in
     div []
-        [ img [ src image.src, alt image.alt ] []
+        [ img [ src image.src, alt image.alt, css [ teaserImageStyle ] ] []
         , p []
             [ a [ href teaser.url ] [ text teaser.title ] ]
         , p
@@ -168,7 +173,7 @@ viewStoryTeasers teasers =
                 |> map
                     (\{ description, image, slug, title } ->
                         div [ css [ storyTeaserStyle ] ]
-                            [ img [ src image.src, alt image.alt ] []
+                            [ img [ src image.src, alt image.alt, css [ teaserImageStyle ] ] []
                             , a [ href ("/stories/" ++ slug) ] [ text title ]
                             , p [] [ text description ]
                             ]

--- a/src/Page/Story/View.elm
+++ b/src/Page/Story/View.elm
@@ -5,7 +5,7 @@ import Html.Styled.Attributes exposing (alt, css, src)
 import Message exposing (Msg)
 import Page.Shared.View
 import Page.Story.Data
-import Theme.Global exposing (centerContent, pageColumnStyle, pageWrapperStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (centerContent, featureImageStyle, pageColumnStyle, pageWrapperStyle, topTwoColumnsWrapperStyle)
 import Theme.Markdown exposing (markdownToHtml)
 
 
@@ -33,7 +33,7 @@ view story =
                     , div []
                         (case story.maybeImages of
                             Just images ->
-                                List.map (\image -> img [ src image.src, alt image.alt ] []) images
+                                List.map (\image -> img [ src image.src, alt image.alt, css [ featureImageStyle ] ] []) images
 
                             Nothing ->
                                 [ text "" ]

--- a/src/Page/Story/View.elm
+++ b/src/Page/Story/View.elm
@@ -1,11 +1,11 @@
 module Page.Story.View exposing (view)
 
-import Html.Styled exposing (Html, a, div, h1, img, li, p, text, ul)
-import Html.Styled.Attributes exposing (alt, css, href, src)
+import Html.Styled exposing (Html, div, h1, img, p, text)
+import Html.Styled.Attributes exposing (alt, css, src)
 import Message exposing (Msg)
 import Page.Shared.View
 import Page.Story.Data
-import Theme.Global exposing (centerContent)
+import Theme.Global exposing (centerContent, pageColumnStyle, pageWrapperStyle, topTwoColumnsWrapperStyle)
 import Theme.Markdown exposing (markdownToHtml)
 
 
@@ -13,28 +13,45 @@ view : Page.Story.Data.Story -> Html Msg
 view story =
     div [ css [ centerContent ] ]
         [ h1 [] [ text story.title ]
-        , div []
-            [ case story.maybeGroupOrIndividual of
-                Just groupOrIndividual ->
-                    p [] [ text groupOrIndividual ]
+        , div [ css [ pageWrapperStyle ] ]
+            [ div [ css [ topTwoColumnsWrapperStyle ] ]
+                [ div [ css [ pageColumnStyle ] ]
+                    [ div []
+                        [ case story.maybeGroupOrIndividual of
+                            Just groupOrIndividual ->
+                                p [] [ text groupOrIndividual ]
 
-                Nothing ->
-                    text ""
-            , case story.maybeLocation of
-                Just location ->
-                    p [] [ text location ]
+                            Nothing ->
+                                text ""
+                        , case story.maybeLocation of
+                            Just location ->
+                                p [] [ text location ]
 
-                Nothing ->
-                    text ""
+                            Nothing ->
+                                text ""
+                        ]
+                    , div []
+                        (case story.maybeImages of
+                            Just images ->
+                                List.map (\image -> img [ src image.src, alt image.alt ] []) images
+
+                            Nothing ->
+                                [ text "" ]
+                        )
+                    ]
+                , div [ css [ pageColumnStyle ] ]
+                    (markdownToHtml story.fullTextMarkdown)
+                ]
+            , viewColumnWrapper (Page.Shared.View.viewGuideTeaserList story.relatedGuideList)
             ]
-        , div []
-            (case story.maybeImages of
-                Just images ->
-                    List.map (\image -> img [ src image.src, alt image.alt ] []) images
-
-                Nothing ->
-                    [ text "" ]
-            )
-        , div [] (markdownToHtml story.fullTextMarkdown)
-        , Page.Shared.View.viewGuideTeaserList story.relatedGuideList
         ]
+
+
+viewColumnWrapper : Html Msg -> Html Msg
+viewColumnWrapper content =
+    if content /= text "" then
+        div [ css [ pageColumnStyle ] ]
+            [ content ]
+
+    else
+        text ""

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,6 +1,6 @@
-module Theme.Global exposing (centerContent, globalStyles, lightTeal, pageColumnBlockStyle, pageColumnStyle, pageWrapperStyle, purple, teal, topTwoColumnsWrapperStyle)
+module Theme.Global exposing (centerContent, embeddedAudioStyle, embeddedVideoStyle, featureImageStyle, globalStyles, lightTeal, pageColumnBlockStyle, pageColumnStyle, pageWrapperStyle, purple, teal, teaserImageStyle, topTwoColumnsWrapperStyle)
 
-import Css exposing (Color, Style, absolute, alignItems, auto, batch, boxSizing, center, color, column, contentBox, displayFlex, flex, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, int, justifyContent, lastChild, left, margin, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noWrap, overflow, padding, padding2, pct, position, px, rem, row, top, width, zero)
+import Css exposing (Color, Style, absolute, alignItems, auto, batch, boxSizing, center, color, column, contentBox, displayFlex, flex, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, int, justifyContent, lastChild, left, margin, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noWrap, overflow, padding, padding2, pct, position, px, rem, row, top, width, zero)
 import Css.Global exposing (global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html)
@@ -44,11 +44,6 @@ maxTabletLandscape =
 maxSmallDesktop : Float
 maxSmallDesktop =
     1500
-
-
-withMediaMobileOnly : List Style -> Style
-withMediaMobileOnly =
-    withMedia [ only screen [ Media.maxWidth (px (maxMobile - 1)) ] ]
 
 
 withMediaTabletPortraitUp : List Style -> Style
@@ -136,16 +131,66 @@ globalStyles =
 -- Helpers
 
 
+featureImageStyle : Style
+featureImageStyle =
+    batch
+        [ width (pct 100)
+        , height auto
+        , maxWidth (px (maxSmallDesktop / 3))
+        ]
+
+
+teaserImageStyle : Style
+teaserImageStyle =
+    batch
+        [ width (pct 100)
+        , height auto
+        , maxWidth (px (maxTabletPortrait / 3))
+        ]
+
+
+embeddedVideoStyle : Style
+embeddedVideoStyle =
+    batch
+        [ width (pct 100)
+        , height auto
+        , maxWidth (px (maxTabletLandscape / 3))
+        ]
+
+
+embeddedAudioStyle : Style
+embeddedAudioStyle =
+    batch
+        [ width (pct 100)
+        , height auto
+        , maxWidth (px (maxTabletLandscape / 3))
+        ]
+
+
+outerPadding : Style
+outerPadding =
+    batch
+        [ padding2 (rem 2) (rem 1)
+        , withMediaTabletPortraitUp
+            [ padding (rem 3)
+            ]
+        , withMediaTabletLandscapeUp
+            [ padding2 (rem 4) (rem 3)
+            ]
+        ]
+
+
 centerContent : Style
 centerContent =
     batch
-        [ boxSizing contentBox
+        [ alignItems center
+        , boxSizing contentBox
+        , displayFlex
+        , flexDirection column
         , maxWidth (px maxSmallDesktop)
         , marginLeft auto
         , marginRight auto
-        , displayFlex
-        , flexDirection column
-        , alignItems center
+        , outerPadding
         ]
 
 
@@ -157,7 +202,6 @@ pageWrapperStyle =
         , flexDirection column
         , flexWrap noWrap
         , justifyContent center
-        , padding2 (rem 3) (rem 4)
         , withMediaTabletLandscapeUp
             [ flexDirection row
             ]
@@ -182,23 +226,13 @@ topTwoColumnsWrapperStyle =
         ]
 
 
-pageColumnStyle : Style
-pageColumnStyle =
+pageColumnMarginStyle : Style
+pageColumnMarginStyle =
     batch
-        [ alignItems flexStart
-        , displayFlex
-        , flex (int 1)
-        , flexDirection column
-        , justifyContent center
-        , marginBottom (rem 3)
+        [ marginBottom (rem 3)
         , marginRight (rem 3)
-        , maxWidth (px (maxSmallDesktop / 3))
-        , minWidth (px (maxTabletPortrait / 3))
-        , padding (rem 0)
-        , width (pct 100)
         , lastChild
-            [ marginBottom
-                (rem 0)
+            [ marginBottom (rem 0)
             , marginRight (rem 0)
             ]
         , withMediaTabletPortraitUp
@@ -207,14 +241,38 @@ pageColumnStyle =
         ]
 
 
+columnWidthStyle : Style
+columnWidthStyle =
+    batch
+        [ maxWidth (px (maxSmallDesktop / 3))
+        , width (pct 100)
+        , withMediaTabletPortraitUp
+            [ minWidth (px (maxTabletPortrait / 3))
+            ]
+        ]
+
+
+pageColumnStyle : Style
+pageColumnStyle =
+    batch
+        [ alignItems flexStart
+        , columnWidthStyle
+        , displayFlex
+        , flex (int 1)
+        , flexDirection column
+        , justifyContent center
+        , pageColumnMarginStyle
+        ]
+
+
 pageColumnBlockStyle : Style
 pageColumnBlockStyle =
     batch
-        [ lastChild
+        [ marginBottom (rem 4)
+        , marginTop (rem 0)
+        , lastChild
             [ marginBottom (rem 0)
             ]
-        , marginBottom (rem 4)
-        , marginTop (rem 0)
         ]
 
 

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,7 +1,7 @@
-module Theme.Global exposing (centerContent, globalStyles)
+module Theme.Global exposing (centerContent, globalStyles, pageColumnBlockStyle, pageColumnStyle, pageWrapperStyle, topTwoColumnsWrapperStyle)
 
-import Css exposing (Style, absolute, alignItems, auto, batch, boxSizing, center, ch, column, contentBox, displayFlex, flexDirection, fontFamilies, height, hidden, left, marginLeft, marginRight, maxWidth, overflow, position, px, top, width)
-import Css.Global exposing (global, typeSelector)
+import Css exposing (Style, absolute, alignItems, auto, batch, boxSizing, center, column, contentBox, displayFlex, flex, flexDirection, flexStart, flexWrap, fontFamilies, height, hidden, int, justifyContent, lastChild, left, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noWrap, overflow, padding, padding2, pct, position, px, rem, row, top, width, wrap)
+import Css.Global exposing (col, global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html)
 
@@ -31,24 +31,9 @@ maxMobile =
     600
 
 
-withMediaMobileOnly : List Style -> Style
-withMediaMobileOnly =
-    withMedia [ only screen [ Media.maxWidth (px (maxMobile - 1)) ] ]
-
-
-withMediaTabletPortraitUp : List Style -> Style
-withMediaTabletPortraitUp =
-    withMedia [ only screen [ Media.minWidth (px maxMobile) ] ]
-
-
 maxTabletPortrait : Float
 maxTabletPortrait =
     900
-
-
-withMediaTabletLandscapeUp : List Style -> Style
-withMediaTabletLandscapeUp =
-    withMedia [ only screen [ Media.minWidth (px maxTabletPortrait) ] ]
 
 
 maxTabletLandscape : Float
@@ -56,19 +41,24 @@ maxTabletLandscape =
     1200
 
 
-withMediaSmallDesktopUp : List Style -> Style
-withMediaSmallDesktopUp =
-    withMedia [ only screen [ Media.minWidth (px maxTabletLandscape) ] ]
-
-
 maxSmallDesktop : Float
 maxSmallDesktop =
     1500
 
 
-withMediaMediumDesktopUp : List Style -> Style
-withMediaMediumDesktopUp =
-    withMedia [ only screen [ Media.minWidth (px maxSmallDesktop) ] ]
+withMediaMobileOnly : List Style -> Style
+withMediaMobileOnly =
+    withMedia [ only screen [ Media.maxWidth (px (maxMobile - 1)) ] ]
+
+
+withMediaTabletPortraitUp : List Style -> Style
+withMediaTabletPortraitUp =
+    withMedia [ only screen [ Media.minWidth (px maxTabletPortrait) ] ]
+
+
+withMediaTabletLandscapeUp : List Style -> Style
+withMediaTabletLandscapeUp =
+    withMedia [ only screen [ Media.minWidth (px maxTabletLandscape) ] ]
 
 
 
@@ -119,12 +109,80 @@ centerContent : Style
 centerContent =
     batch
         [ boxSizing contentBox
-        , maxWidth (ch 60)
+        , maxWidth (px maxSmallDesktop)
         , marginLeft auto
         , marginRight auto
         , displayFlex
         , flexDirection column
         , alignItems center
+        ]
+
+
+pageWrapperStyle : Style
+pageWrapperStyle =
+    batch
+        [ alignItems flexStart
+        , displayFlex
+        , flexDirection column
+        , flexWrap noWrap
+        , justifyContent center
+        , padding2 (rem 3) (rem 4)
+        , withMediaTabletLandscapeUp
+            [ flexDirection row
+            ]
+        ]
+
+
+topTwoColumnsWrapperStyle : Style
+topTwoColumnsWrapperStyle =
+    batch
+        [ alignItems flexStart
+        , displayFlex
+        , flexDirection column
+        , flexWrap noWrap
+        , justifyContent center
+        , marginBottom (rem 3)
+        , width (pct 100)
+        , withMediaTabletPortraitUp
+            [ flex (int 2)
+            , flexDirection row
+            , marginRight (rem 3)
+            ]
+        ]
+
+
+pageColumnStyle : Style
+pageColumnStyle =
+    batch
+        [ alignItems flexStart
+        , displayFlex
+        , flex (int 1)
+        , flexDirection column
+        , justifyContent center
+        , marginBottom (rem 3)
+        , marginRight (rem 3)
+        , maxWidth (px (maxSmallDesktop / 3))
+        , padding (rem 0)
+        , width (pct 100)
+        , lastChild
+            [ marginBottom
+                (rem 0)
+            , marginRight (rem 0)
+            ]
+        , withMediaTabletPortraitUp
+            [ marginBottom (rem 0)
+            ]
+        ]
+
+
+pageColumnBlockStyle : Style
+pageColumnBlockStyle =
+    batch
+        [ lastChild
+            [ marginBottom (rem 0)
+            ]
+        , marginBottom (rem 4)
+        , marginTop (rem 0)
         ]
 
 

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,6 +1,6 @@
 module Theme.Global exposing (centerContent, globalStyles, lightTeal, pageColumnBlockStyle, pageColumnStyle, pageWrapperStyle, purple, teal, topTwoColumnsWrapperStyle)
 
-import Css exposing (Color, Style, absolute, alignItems, auto, batch, boxSizing, center, color, column, contentBox, displayFlex, flex, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, int, justifyContent, lastChild, left, margin, marginBottom, marginLeft, marginRight, marginTop, maxWidth, noWrap, overflow, padding, padding2, pct, position, px, rem, row, top, width, zero)
+import Css exposing (Color, Style, absolute, alignItems, auto, batch, boxSizing, center, color, column, contentBox, displayFlex, flex, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, int, justifyContent, lastChild, left, margin, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noWrap, overflow, padding, padding2, pct, position, px, rem, row, top, width, zero)
 import Css.Global exposing (global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html)
@@ -193,6 +193,7 @@ pageColumnStyle =
         , marginBottom (rem 3)
         , marginRight (rem 3)
         , maxWidth (px (maxSmallDesktop / 3))
+        , minWidth (px (maxTabletPortrait / 3))
         , padding (rem 0)
         , width (pct 100)
         , lastChild

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -1,7 +1,7 @@
 module Theme.PageTemplate exposing (view)
 
 import CookieBanner
-import Css exposing (Style, alignItems, backgroundColor, batch, center, column, displayFlex, flex2, flexBasis, flexDirection, height, int, minHeight, pct, vh, width)
+import Css exposing (Style, alignItems, backgroundColor, batch, center, column, displayFlex, flex2, flexBasis, flexDirection, height, hidden, int, minHeight, none, overflowX, pct, vh, width)
 import Html.Styled exposing (Html, button, div, main_, text)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)
@@ -39,6 +39,7 @@ mainStyle : Style
 mainStyle =
     batch
         [ backgroundColor lightTeal
+        , overflowX hidden
         ]
 
 

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -1,7 +1,7 @@
 module Theme.PageTemplate exposing (view)
 
 import CookieBanner
-import Css exposing (Style, alignItems, backgroundColor, batch, center, column, displayFlex, flex2, flexBasis, flexDirection, height, hidden, int, minHeight, none, overflowX, pct, vh, width)
+import Css exposing (Style, backgroundColor, batch, hidden, overflowX, pct, width)
 import Html.Styled exposing (Html, button, div, main_, text)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)
@@ -10,7 +10,7 @@ import I18n.Translate exposing (translate)
 import Message exposing (Msg(..))
 import Shared exposing (Model)
 import Theme.FooterTemplate as FooterTemplate
-import Theme.Global exposing (globalStyles, lightTeal, teal)
+import Theme.Global exposing (centerContent, globalStyles, lightTeal, pageWrapperStyle)
 
 
 view : Model -> Html Msg -> Html Msg
@@ -20,12 +20,12 @@ view model content =
         t =
             translate model.language
     in
-    div [ css [ pageWrapperStyle ] ]
+    div []
         [ globalStyles
-        , div [ css [ pageStyle ] ]
-            [ main_ []
+        , div [ css [ mainStyle ] ]
+            [ main_ [ css [ centerContent ] ]
                 [ button [ onClick LanguageChangeRequested ] [ text (t ChangeLanguage) ]
-                , div []
+                , div [ css [ pageWrapperStyle ] ]
                     [ content
                     ]
                 ]
@@ -40,23 +40,5 @@ mainStyle =
     batch
         [ backgroundColor lightTeal
         , overflowX hidden
-        ]
-
-
-pageStyle : Style
-pageStyle =
-    batch
-        [ width (pct 100)
-        ]
-
-
-pageWrapperStyle : Style
-pageWrapperStyle =
-    batch
-        [ alignItems center
-        , displayFlex
-        , flexDirection column
-        , height (pct 100)
-        , minHeight (vh 100)
-        , backgroundColor teal
+        , width (pct 100)
         ]

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -1,7 +1,7 @@
 module Theme.PageTemplate exposing (view)
 
 import CookieBanner
-import Css exposing (Style, alignItems, auto, batch, center, column, displayFlex, flex2, flexBasis, flexDirection, height, int, minHeight, pct, vh)
+import Css exposing (Style, alignItems, batch, center, column, displayFlex, flexDirection, height, minHeight, pct, vh, width)
 import Html.Styled exposing (Html, button, div, main_, text)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)
@@ -11,11 +11,6 @@ import Message exposing (Msg(..))
 import Shared exposing (Model)
 import Theme.FooterTemplate as FooterTemplate
 import Theme.Global exposing (globalStyles)
-import Theme.HeaderTemplate as HeaderTemplate
-
-
-type alias PageInfo =
-    { title : Key, content : Html Msg }
 
 
 view : Model -> Html Msg -> Html Msg
@@ -28,7 +23,7 @@ view model content =
     div [ css [ pageWrapperStyle ] ]
         [ globalStyles
         , div [ css [ pageStyle ] ]
-            [ main_ [ css [ mainStyle ] ]
+            [ main_ []
                 [ button [ onClick LanguageChangeRequested ] [ text (t ChangeLanguage) ]
                 , div []
                     [ content
@@ -40,16 +35,11 @@ view model content =
         ]
 
 
-mainStyle : Style
-mainStyle =
-    batch
-        []
-
-
 pageStyle : Style
 pageStyle =
     batch
-        [ flex2 (int 1) (int 0), flexBasis auto ]
+        [ width (pct 100)
+        ]
 
 
 pageWrapperStyle : Style


### PR DESCRIPTION
Fixes #113 

## Description

- Adds a generic set of responsive layout containers to provide sensible styling at mobile, tablet, & desktop
- Styles the home page, guide & story pages, and some shared elements like teaser images
- Styles have been placed in global as they are reused throughout
-  If an optional part of the design is not present (eg a list of related guides) then the design should fill the remaining space
- I've tried not to let any of the global classes I defined get so big that they can't be broken up and reused, but it's hard to know when that's helpful/ when that's a hindrance so if we want to break them down a bit more/ join some of them back together again let me know!

- I've also created a big layouts file which has been a really helpful reference while making this. I guess this might be helpful as visual acceptance criteria, to check that the layout looks as it should:

https://www.figma.com/file/rLewb9kn4mUt8lLI0wuC7f/Team-wilder-layouts?node-id=0-1&t=9wL7svPl8A1zfV88-0

## still to do

- The header & footer - will leave these while Ivan is making footer logos & doing the header h1 thingmy - think it would be better to get these in first - but have some layouts designed for them. Will make a new issue.
- The generic styling library we wanted to add to notion - will have a think about this next week in my in between times, once this is in

@geeksforsocialchange/developers
