### PR TITLE
fix: Use github creds to authenticate CMS

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -1,5 +1,6 @@
 backend:
-  name: git-gateway
+  name: github
+  repo: geeksforsocialchange/teamwilder
   branch: main # Branch to update (optional; defaults to master)
 publish_mode: editorial_workflow
 media_folder: public/images/uploads

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex" />
     <title>Content Manager</title>
-    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
   </head>
   <body>
     <!-- Include the script that builds the page and powers Decap CMS -->


### PR DESCRIPTION
Alteration to #7

## Description

- Use github auth instead of Netlify identity

@geeksforsocialchange/developers
