### PR TITLE
Style header & move translate button into header

### DIFF
--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,6 +1,6 @@
-module Theme.Global exposing (centerContent, embeddedAudioStyle, embeddedVideoStyle, featureImageStyle, globalStyles, lightTeal, mainContainerStyles, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle)
+module Theme.Global exposing (centerContent, embeddedAudioStyle, embeddedVideoStyle, featureImageStyle, globalStyles, lightTeal, mainContainerStyles, outerPadding, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, withMediaMobileUp)
 
-import Css exposing (Color, Style, absolute, alignItems, auto, batch, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contentBox, displayFlex, flex, flex3, flexBasis, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, int, justifyContent, lastChild, left, listStyle, margin, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noWrap, none, overflow, padding, padding2, pct, position, px, rem, row, top, width, wrap, zero)
+import Css exposing (Color, Style, absolute, alignItems, auto, batch, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contentBox, displayFlex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, int, justifyContent, lastChild, left, listStyle, margin, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noWrap, none, overflow, padding, padding2, pct, position, px, rem, row, spaceBetween, top, width, wrap, zero)
 import Css.Global exposing (global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html)
@@ -44,6 +44,11 @@ maxTabletLandscape =
 maxSmallDesktop : Float
 maxSmallDesktop =
     1500
+
+
+withMediaMobileUp : List Style -> Style
+withMediaMobileUp =
+    withMedia [ only screen [ Media.minWidth (px maxMobile) ] ]
 
 
 withMediaTabletPortraitUp : List Style -> Style

--- a/src/Theme/HeaderTemplate.elm
+++ b/src/Theme/HeaderTemplate.elm
@@ -1,6 +1,6 @@
 module Theme.HeaderTemplate exposing (view)
 
-import Css exposing (Style, alignItems, baseline, batch, center, column, displayFlex, flexDirection, flexEnd, flexStart, flexWrap, fontFamilies, fontSize, justifyContent, left, margin, margin2, marginBottom, marginRight, marginTop, noWrap, rem, right, row, spaceBetween, textAlign, zero)
+import Css exposing (Style, alignItems, auto, baseline, batch, center, column, displayFlex, flexDirection, flexEnd, flexStart, flexWrap, fontFamilies, fontSize, int, justifyContent, left, lineHeight, margin, margin2, marginBottom, marginRight, marginTop, maxWidth, noWrap, none, pct, px, rem, right, row, spaceBetween, textAlign, textDecoration, width, zero)
 import Html.Styled exposing (Html, a, button, div, h1, header, input, label, node, text)
 import Html.Styled.Attributes exposing (attribute, css, href, id, placeholder, property, type_)
 import Html.Styled.Events exposing (on, onClick)
@@ -46,7 +46,12 @@ viewSiteTitle route siteTitle =
 
     else
         div [ css [ headerBrandStyle, headerTitleStyle ] ]
-            [ a [ href "/" ]
+            [ a
+                [ href "/"
+                , css
+                    [ textDecoration none
+                    ]
+                ]
                 [ text siteTitle
                 ]
             ]
@@ -89,6 +94,7 @@ headerBrandStyle =
     batch
         [ fontSize (rem 4)
         , fontFamilies [ "Ludicrous" ]
+        , lineHeight (rem 4)
         , margin zero
         ]
 
@@ -140,5 +146,7 @@ headerLinkStyle =
 headerTitleStyle : Style
 headerTitleStyle =
     batch
-        [ marginRight (rem 3)
+        [ maxWidth (px 336)
+        , withMediaMobileUp
+            [ marginRight (rem 3) ]
         ]

--- a/src/Theme/HeaderTemplate.elm
+++ b/src/Theme/HeaderTemplate.elm
@@ -1,19 +1,20 @@
 module Theme.HeaderTemplate exposing (view)
 
-import Css exposing (Style, batch, fontFamilies, fontSize, margin, rem, zero)
-import Html.Styled exposing (Html, a, div, h1, header, input, label, node, text)
+import Css exposing (Style, alignItems, baseline, batch, center, column, displayFlex, flexDirection, flexEnd, flexStart, flexWrap, fontFamilies, fontSize, justifyContent, left, margin, margin2, marginBottom, marginRight, marginTop, noWrap, rem, right, row, spaceBetween, textAlign, zero)
+import Html.Styled exposing (Html, a, button, div, h1, header, input, label, node, text)
 import Html.Styled.Attributes exposing (attribute, css, href, id, placeholder, property, type_)
-import Html.Styled.Events exposing (on)
+import Html.Styled.Events exposing (on, onClick)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..), translate)
 import Json.Decode
 import List
-import Message exposing (Msg)
+import Message exposing (Msg(..))
 import Page.Guide.Data
 import Page.GuideTeaser
 import Page.Shared.View
 import Route exposing (Route(..))
 import Shared exposing (Model, Request(..))
+import Theme.Global exposing (centerContent, outerPadding, withMediaMobileUp)
 
 
 view : Model -> Html Msg
@@ -23,24 +24,28 @@ view model =
         t =
             translate model.language
     in
-    header []
+    header [ css [ headerContainerStyle ] ]
         [ viewSiteTitle model.page (t SiteTitle)
-        , case model.page of
-            Guides ->
-                searchInput model
+        , div [ css [ searchButtonsContainerStyle ] ]
+            [ button [ onClick LanguageChangeRequested ]
+                [ text (t ChangeLanguage) ]
+            , case model.page of
+                Guides ->
+                    searchInput model
 
-            _ ->
-                a [ href "/guides" ] [ text <| t FooterGuidesLinkText ]
+                _ ->
+                    a [ href "/guides", css [ headerLinkStyle ] ] [ text <| t FooterGuidesLinkText ]
+            ]
         ]
 
 
 viewSiteTitle : Route -> String -> Html Msg
 viewSiteTitle route siteTitle =
     if route == Index then
-        h1 [ css [ headerBrandStyle ] ] [ text siteTitle ]
+        h1 [ css [ headerBrandStyle, headerTitleStyle ] ] [ text siteTitle ]
 
     else
-        div [ css [ headerBrandStyle ] ]
+        div [ css [ headerBrandStyle, headerTitleStyle ] ]
             [ a [ href "/" ]
                 [ text siteTitle
                 ]
@@ -85,4 +90,55 @@ headerBrandStyle =
         [ fontSize (rem 4)
         , fontFamilies [ "Ludicrous" ]
         , margin zero
+        ]
+
+
+headerContainerStyle : Style
+headerContainerStyle =
+    batch
+        [ alignItems baseline
+        , centerContent
+        , displayFlex
+        , flexDirection column
+        , flexWrap noWrap
+        , justifyContent center
+        , outerPadding
+        , withMediaMobileUp
+            [ flexDirection row
+            , justifyContent spaceBetween
+            ]
+        ]
+
+
+searchButtonsContainerStyle : Style
+searchButtonsContainerStyle =
+    batch
+        [ alignItems flexStart
+        , displayFlex
+        , flexDirection column
+        , flexWrap noWrap
+        , justifyContent center
+        , marginTop (rem 2)
+        , marginBottom (rem 0)
+        , withMediaMobileUp
+            [ margin2 (rem 2) (rem 0)
+            , alignItems flexEnd
+            ]
+        ]
+
+
+headerLinkStyle : Style
+headerLinkStyle =
+    batch
+        [ textAlign left
+        , withMediaMobileUp
+            [ textAlign right
+            ]
+        ]
+
+
+headerTitleStyle : Style
+headerTitleStyle =
+    batch
+        [ marginRight (rem 3)
         ]

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -2,32 +2,23 @@ module Theme.PageTemplate exposing (view)
 
 import CookieBanner
 import Css exposing (Style, backgroundColor, batch, hidden, overflowX, pct, width)
-import Html.Styled exposing (Html, button, div, main_, text)
+import Html.Styled exposing (Html, div, main_)
 import Html.Styled.Attributes exposing (css)
-import Html.Styled.Events exposing (onClick)
 import I18n.Keys exposing (Key(..))
-import I18n.Translate exposing (translate)
 import Message exposing (Msg(..))
 import Shared exposing (Model)
 import Theme.FooterTemplate as FooterTemplate
-import Theme.Global exposing (globalStyles, lightTeal, mainContainerStyles)
+import Theme.Global exposing (centerContent, globalStyles, lightTeal, mainContainerStyles)
 import Theme.HeaderTemplate as HeaderTemplate
 
 
 view : Model -> Html Msg -> Html Msg
 view model content =
-    let
-        t : Key -> String
-        t =
-            translate model.language
-    in
     div []
         [ globalStyles
         , div
             [ css [ pageWrapperStyles ] ]
             [ HeaderTemplate.view model
-            , button [ onClick LanguageChangeRequested ]
-                [ text (t ChangeLanguage) ]
             , main_ [ css [ mainContainerStyles ] ]
                 [ content
                 ]


### PR DESCRIPTION
Fixes #143 

## Description

- Moves translate button into header
- Adds header styling to center content with space between

@geeksforsocialchange/developers
