### PR TITLE
Translate ancillary pages

### DIFF
--- a/content/pages/cy/about.md
+++ b/content/pages/cy/about.md
@@ -2,11 +2,11 @@
 title: "[cCc] Ynghylch"
 ---
 
-## [cCc] Header
+## [cCc] Welsh header
 
-#### [cCc] A subheader
+#### [cCc] A welsh subheader
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eu mollis urna, vel faucibus arcu. Vestibulum lacinia tortor dictum tempor dignissim. Donec lacus urna, varius non diam maximus, consequat faucibus augue. Morbi convallis sagittis enim, quis finibus libero interdum dapibus. Curabitur luctus mollis elit, sed molestie risus congue consectetur.
+Welsh content Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eu mollis urna, vel faucibus arcu. Vestibulum lacinia tortor dictum tempor dignissim. Donec lacus urna, varius non diam maximus, consequat faucibus augue. Morbi convallis sagittis enim, quis finibus libero interdum dapibus. Curabitur luctus mollis elit, sed molestie risus congue consectetur.
 
 Pellentesque egestas nec lacus ut sollicitudin. Fusce faucibus posuere lobortis. Integer rutrum dictum elementum. Donec id massa id odio convallis commodo. Suspendisse lorem augue, blandit quis lacinia eget, ullamcorper ornare nulla. Suspendisse ullamcorper eleifend pellentesque. Nulla aliquet hendrerit elementum. Maecenas tempor lorem vestibulum sollicitudin sollicitudin. Proin nisl enim, maximus et ex a, cursus malesuada orci. Sed ac pharetra dolor.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "npm run generate && vite build",
     "generate": "npm run generate_guides && npm run generate_stories && npm run generate_pages",
-    "generate_pages": "m2j -o ./data/pages.json -c ./content/pages/en/*.md",
+    "generate_pages": "mkdir -p ./data/pages && m2j -o ./data/pages/en.json -c ./content/pages/en/*.md && m2j -o ./data/pages/cy.json -c ./content/pages/cy/*.md",
     "generate_guides": "mkdir -p ./data/guides && m2j -o ./data/guides/en.json -c ./content/guides/en/*.md && m2j -o ./data/guides/cy.json -c ./content/guides/cy/*.md",
     "generate_stories": "m2j -o ./data/stories.json -c ./content/stories/en/*.md",
     "format": "elm-format src",

--- a/src/Page/Data.elm
+++ b/src/Page/Data.elm
@@ -1,10 +1,16 @@
-module Page.Data exposing (Page, pageDictDecoder, pageFromSlug, pageTitleFromSlug)
+module Page.Data exposing (Page, Pages, pageFromSlug, pageLanguageDictDecoder, pageTitleFromSlug)
 
 import Dict exposing (Dict)
 import I18n.Keys exposing (Key(..))
-import I18n.Translate exposing (Language, translate)
+import I18n.Translate exposing (Language(..), translate)
 import Json.Decode
 import Json.Decode.Extra
+
+
+type alias Pages =
+    { cy : Dict String Page
+    , en : Dict String Page
+    }
 
 
 type alias Page =
@@ -40,14 +46,46 @@ pageDictDecoder =
         )
 
 
-pageFromSlug : Language -> Dict String Page -> String -> Page
+pageLanguageDictDecoder : Json.Decode.Decoder Pages
+pageLanguageDictDecoder =
+    Json.Decode.map2 Pages
+        (Json.Decode.field "cy" pageDictDecoder)
+        (Json.Decode.field "en" pageDictDecoder)
+
+
+pagesInPreferredLanguage : Language -> Pages -> Dict String Page
+pagesInPreferredLanguage language pages =
+    case language of
+        English ->
+            pages.en
+
+        Welsh ->
+            pages.cy
+
+
+fallbackPages : Language -> Pages -> Dict String Page
+fallbackPages language pages =
+    case language of
+        English ->
+            pages.cy
+
+        Welsh ->
+            pages.en
+
+
+pageFromSlug : Language -> Pages -> String -> Page
 pageFromSlug language pages slug =
-    case Dict.get slug pages of
-        Just aPage ->
-            aPage
+    case Dict.get slug (pagesInPreferredLanguage language pages) of
+        Just aGuide ->
+            aGuide
 
         Nothing ->
-            blankPage language
+            case Dict.get slug (fallbackPages language pages) of
+                Just aGuide ->
+                    aGuide
+
+                Nothing ->
+                    blankPage language
 
 
 pageTitleFromSlug : Dict String Page -> String -> String

--- a/src/Page/Guide/Data.elm
+++ b/src/Page/Guide/Data.elm
@@ -1,4 +1,4 @@
-module Page.Guide.Data exposing (Guide, Guides, guideDictDecoder, guideFromSlug, guideLanguageDictDecoder, teaserListFromGuideDict)
+module Page.Guide.Data exposing (Guide, Guides, guideFromSlug, guideLanguageDictDecoder, teaserListFromGuideDict)
 
 import Dict exposing (Dict)
 import I18n.Keys exposing (Key(..))

--- a/src/Page/Shared/Data.elm
+++ b/src/Page/Shared/Data.elm
@@ -10,7 +10,7 @@ import Page.Story.Data
 type alias Content =
     { guides : Page.Guide.Data.Guides
     , stories : Dict String Page.Story.Data.Story
-    , pages : Dict String Page.Data.Page
+    , pages : Page.Data.Pages
     }
 
 
@@ -23,7 +23,7 @@ contentDictDecoder flags =
         Err _ ->
             { guides = { cy = Dict.empty, en = Dict.empty }
             , stories = Dict.empty
-            , pages = Dict.empty
+            , pages = { cy = Dict.empty, en = Dict.empty }
             }
 
 
@@ -32,4 +32,4 @@ flagsDictDecoder =
     Json.Decode.map3 Content
         (Json.Decode.field "guides" Page.Guide.Data.guideLanguageDictDecoder)
         (Json.Decode.field "stories" Page.Story.Data.storyDictDecoder)
-        (Json.Decode.field "pages" Page.Data.pageDictDecoder)
+        (Json.Decode.field "pages" Page.Data.pageLanguageDictDecoder)

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -32,8 +32,11 @@ type alias Content =
         { cy : Dict String Page.Guide.Data.Guide
         , en : Dict String Page.Guide.Data.Guide
         }
+    , pages :
+        { cy : Dict String Page.Data.Page
+        , en : Dict String Page.Data.Page
+        }
     , stories : Dict String Page.Story.Data.Story
-    , pages : Dict String Page.Data.Page
     }
 
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -3,9 +3,10 @@ import { Elm } from "/src/Main.elm";
 import SearchInput from "/src/js/search";
 
 import cyGuides from "../../data/guides/cy.json";
+import cyPages from "../../data/pages/cy.json";
 import enGuides from "../../data/guides/en.json";
+import enPages from "../../data/pages/en.json";
 import stories from "../../data/stories.json";
-import pages from "../../data/pages.json";
 
 customElements.define("search-input", SearchInput);
 
@@ -18,7 +19,7 @@ const app = Elm.Main.init({
     hasConsented,
     guides: { cy: cyGuides, en: enGuides },
     stories,
-    pages,
+    pages: { cy: cyPages, en: enPages },
   },
 });
 


### PR DESCRIPTION
Fixes #120 

## Description

- Reads in files from cy & en folders in content/pages and shows appropriate page for selected language

## Thoughts

- I've done this the quickest way possible but am left wondering if I could have done some refactoring to use a union type for this & the guides, as there's a lot of overlap. I started to try doing this but quickly ran into some tricky bits with the decoders so have left for now, but might be worth considering if we need to translate stories too.

@geeksforsocialchange/developers
