### PR TITLE
Make teaser images square

### DIFF
--- a/src/Page/Shared/View.elm
+++ b/src/Page/Shared/View.elm
@@ -155,12 +155,11 @@ viewGuideTeaser teaser =
                     defaultTeaserImg
     in
     li [ css [ teaserContainerStyle ] ]
-        [ span
-            [ attribute "aria-label" image.alt
-            , attribute "role" "img"
+        [ img
+            [ alt image.alt
+            , src image.src
             , css
-                [ backgroundImage (url image.src)
-                , roundedCornerStyle
+                [ roundedCornerStyle
                 , teaserImageStyle
                 ]
             ]
@@ -205,12 +204,11 @@ viewStoryTeasers teasers =
                 |> map
                     (\{ description, image, slug, title } ->
                         div [ css [ storyteaserContainerStyle ] ]
-                            [ span
-                                [ attribute "aria-label" image.alt
-                                , attribute "role" "img"
+                            [ img
+                                [ alt image.alt
+                                , src image.src
                                 , css
-                                    [ backgroundImage (url image.src)
-                                    , roundedCornerStyle
+                                    [ roundedCornerStyle
                                     , teaserImageStyle
                                     ]
                                 ]

--- a/src/Page/Shared/View.elm
+++ b/src/Page/Shared/View.elm
@@ -1,7 +1,7 @@
 module Page.Shared.View exposing (AudioMeta, StoryTeaser, VideoMeta, actionTeaserDecoder, actionTeaserListDecoder, audioDecoder, defaultTeaserImg, guideTeaserDecoder, imageDecoder, interalGuideTeaserListDecoder, internalGuideTeaserDecoder, storyTeaserDecoder, videoDecoder, viewAudio, viewGuideTeaserList, viewStoryTeasers, viewVideo)
 
 import Css exposing (Style, backgroundImage, batch, center, column, displayFlex, flexDirection, flexWrap, height, justifyContent, listStyle, maxWidth, none, px, url, wrap)
-import Html.Styled exposing (Html, a, div, i, iframe, img, li, p, summary, text, ul)
+import Html.Styled exposing (Html, a, div, i, iframe, img, li, p, span, summary, text, ul)
 import Html.Styled.Attributes exposing (alt, attribute, autoplay, css, href, src, title)
 import Json.Decode exposing (Decoder)
 import List exposing (map, sortBy)
@@ -155,7 +155,16 @@ viewGuideTeaser teaser =
                     defaultTeaserImg
     in
     li [ css [ teaserContainerStyle ] ]
-        [ div [ alt image.alt, css [ backgroundImage (url image.src), roundedCornerStyle, teaserImageStyle ] ] []
+        [ span
+            [ attribute "aria-label" image.alt
+            , attribute "role" "img"
+            , css
+                [ backgroundImage (url image.src)
+                , roundedCornerStyle
+                , teaserImageStyle
+                ]
+            ]
+            []
         , p [ css [ teaserRowStyle ] ]
             [ a [ href teaser.url ] [ text teaser.title ] ]
         , viewGuideTeaserSummary teaser.summary
@@ -196,7 +205,16 @@ viewStoryTeasers teasers =
                 |> map
                     (\{ description, image, slug, title } ->
                         div [ css [ storyteaserContainerStyle ] ]
-                            [ div [ alt image.alt, css [ backgroundImage (url image.src), roundedCornerStyle, teaserImageStyle ] ] []
+                            [ span
+                                [ attribute "aria-label" image.alt
+                                , attribute "role" "img"
+                                , css
+                                    [ backgroundImage (url image.src)
+                                    , roundedCornerStyle
+                                    , teaserImageStyle
+                                    ]
+                                ]
+                                []
                             , a [ href ("/stories/" ++ slug) ] [ text title ]
                             , p [] [ text description ]
                             ]

--- a/src/Page/Shared/View.elm
+++ b/src/Page/Shared/View.elm
@@ -1,6 +1,6 @@
 module Page.Shared.View exposing (AudioMeta, StoryTeaser, VideoMeta, actionTeaserDecoder, actionTeaserListDecoder, audioDecoder, defaultTeaserImg, guideTeaserDecoder, imageDecoder, interalGuideTeaserListDecoder, internalGuideTeaserDecoder, storyTeaserDecoder, videoDecoder, viewAudio, viewGuideTeaserList, viewStoryTeasers, viewVideo)
 
-import Css exposing (Style, batch, center, column, displayFlex, flexDirection, flexWrap, height, justifyContent, listStyle, maxWidth, none, px, wrap)
+import Css exposing (Style, backgroundImage, batch, center, column, displayFlex, flexDirection, flexWrap, height, justifyContent, listStyle, maxWidth, none, px, url, wrap)
 import Html.Styled exposing (Html, a, div, i, iframe, img, li, p, summary, text, ul)
 import Html.Styled.Attributes exposing (alt, attribute, autoplay, css, href, src, title)
 import Json.Decode exposing (Decoder)
@@ -155,7 +155,7 @@ viewGuideTeaser teaser =
                     defaultTeaserImg
     in
     li [ css [ teaserContainerStyle ] ]
-        [ img [ src image.src, alt image.alt, css [ roundedCornerStyle, teaserImageStyle ] ] []
+        [ div [ alt image.alt, css [ backgroundImage (url image.src), roundedCornerStyle, teaserImageStyle ] ] []
         , p [ css [ teaserRowStyle ] ]
             [ a [ href teaser.url ] [ text teaser.title ] ]
         , viewGuideTeaserSummary teaser.summary
@@ -196,7 +196,7 @@ viewStoryTeasers teasers =
                 |> map
                     (\{ description, image, slug, title } ->
                         div [ css [ storyteaserContainerStyle ] ]
-                            [ img [ src image.src, alt image.alt, css [ roundedCornerStyle, teaserImageStyle ] ] []
+                            [ div [ alt image.alt, css [ backgroundImage (url image.src), roundedCornerStyle, teaserImageStyle ] ] []
                             , a [ href ("/stories/" ++ slug) ] [ text title ]
                             , p [] [ text description ]
                             ]

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,7 +1,7 @@
 module Theme.Global exposing (centerContent, embeddedAudioStyle, embeddedVideoStyle, featureImageStyle, globalStyles, lightTeal, mainContainerStyles, outerPadding, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, withMediaMobileUp)
 
-import Css exposing (Color, Style, absolute, alignItems, auto, batch, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contentBox, displayFlex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, int, justifyContent, lastChild, left, listStyle, margin, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noWrap, none, overflow, padding, padding2, pct, position, px, rem, row, spaceBetween, top, width, wrap, zero)
-import Css.Global exposing (global, typeSelector)
+import Css exposing (Color, Style, absolute, alignItems, auto, backgroundPosition, backgroundRepeat, backgroundSize, batch, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, clip, color, column, contentBox, cover, displayFlex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, int, justifyContent, lastChild, left, listStyle, margin, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, pct, position, property, px, rem, row, spaceBetween, top, width, wrap, zero)
+import Css.Global exposing (global, rect, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html)
 
@@ -170,7 +170,7 @@ teaserContainerStyle =
         , listStyle none
         , marginRight (rem 1.5)
         , marginBottom (rem 1.5)
-        , minWidth (px 200)
+        , minWidth (px 120)
         , width (pct 100)
         , lastChild
             [ marginBottom (rem 0)
@@ -220,9 +220,12 @@ featureImageStyle =
 teaserImageStyle : Style
 teaserImageStyle =
     batch
-        [ width (pct 100)
-        , height auto
-        , maxWidth (px (maxTabletPortrait / 3))
+        [ backgroundRepeat noRepeat
+        , backgroundPosition center
+        , backgroundSize cover
+        , maxWidth (px (maxMobile / 3))
+        , property "aspect-ratio" "1/1"
+        , width (pct 100)
         ]
 
 

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -225,6 +225,7 @@ teaserImageStyle =
         , backgroundSize cover
         , maxWidth (px (maxMobile / 3))
         , property "aspect-ratio" "1/1"
+        , property "object-fit" "cover"
         , width (pct 100)
         ]
 


### PR DESCRIPTION
Fixes #167 

## Description

- Teaser images are square
- Layout is still a bit squiffy on the guides page but will handle this with the refactoring ticket

@geeksforsocialchange/developers
