### PR TITLE
Tidy up time

### DIFF
--- a/src/CookieBanner.elm
+++ b/src/CookieBanner.elm
@@ -1,6 +1,6 @@
 port module CookieBanner exposing (saveConsent, viewCookieBanner)
 
-import Css exposing (Style, backgroundColor, batch, borderTop3, bottom, fixed, padding, paddingBottom, paddingTop, pct, position, px, rem, solid, vw, width)
+import Css exposing (Style, backgroundColor, batch, borderTop3, bottom, fixed, paddingBottom, paddingTop, pct, position, px, rem, solid, width)
 import Html.Styled exposing (Html, button, div, h2, p, text)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)

--- a/src/CookieBanner.elm
+++ b/src/CookieBanner.elm
@@ -1,6 +1,6 @@
 port module CookieBanner exposing (saveConsent, viewCookieBanner)
 
-import Css exposing (Style, backgroundColor, batch, bottom, fixed, position, px, rem, solid, vw, width)
+import Css exposing (Style, backgroundColor, batch, borderTop3, bottom, fixed, padding, paddingBottom, paddingTop, pct, position, px, rem, solid, vw, width)
 import Html.Styled exposing (Html, button, div, h2, p, text)
 import Html.Styled.Attributes exposing (css)
 import Html.Styled.Events exposing (onClick)
@@ -8,7 +8,7 @@ import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language, translate)
 import Message exposing (Msg(..))
 import Shared exposing (CookieState)
-import Theme.Global exposing (lightTeal, purple)
+import Theme.Global exposing (centerContent, lightTeal, purple, withMediaMobileUp)
 
 
 viewCookieBanner : Language -> CookieState -> Html Msg
@@ -29,14 +29,15 @@ viewCookieBannerContent language =
         t =
             translate language
     in
-    div []
-        [ h2 [] [ text (t CookieBannerH2) ]
-        , p
-            [ css [ width (vw 100) ]
+    div [ css [ outerPadding, centerContent ] ]
+        [ div [ css [ innerContainer ] ]
+            [ h2 [] [ text (t CookieBannerH2) ]
+            , p
+                []
+                [ text (t CookieBannerP) ]
+            , button [ onClick CookiesDeclined ] [ text (t CookieDeclineButtonText) ]
+            , button [ onClick CookiesAccepted ] [ text (t CookieAcceptButtonText) ]
             ]
-            [ text (t CookieBannerP) ]
-        , button [ onClick CookiesDeclined ] [ text (t CookieDeclineButtonText) ]
-        , button [ onClick CookiesAccepted ] [ text (t CookieAcceptButtonText) ]
         ]
 
 
@@ -54,6 +55,26 @@ viewCookieBannerStyles =
     batch
         [ backgroundColor lightTeal
         , bottom (px 0)
-        , Css.borderTop3 (rem 0.25) solid purple
+        , borderTop3 (rem 0.25) solid purple
         , position fixed
+        , width (pct 100)
+        ]
+
+
+outerPadding : Style
+outerPadding =
+    batch
+        [ paddingBottom (rem 0.5)
+        , paddingTop (rem 0.5)
+        , withMediaMobileUp
+            [ paddingBottom (rem 0.5)
+            , paddingTop (rem 0.5)
+            ]
+        ]
+
+
+innerContainer : Style
+innerContainer =
+    batch
+        [ width (pct 100)
         ]

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -39,9 +39,6 @@ enStrings key =
         Story404Body ->
             "[cCc] Try searching again [home](\"\\\")"
 
-        Story404Slug ->
-            "story-not-found"
-
         AncillaryPage404Title ->
             "[cCc] Sorry, we can't find that page"
 
@@ -54,9 +51,6 @@ enStrings key =
         ---
         -- Footer
         ---
-        FooterProjectInfo ->
-            "[cCc] Project Info Text"
-
         FooterTitleColumnA ->
             "[cCc] Find out more"
 

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -9,7 +9,6 @@ type Key
       --- 404 content
     | Story404Title
     | Story404Body
-    | Story404Slug
     | Guide404Title
     | Guide404Slug
     | Guide404Body
@@ -17,7 +16,6 @@ type Key
     | AncillaryPage404Title
     | AncillaryPage404Body
       --- Footer
-    | FooterProjectInfo
     | FooterTitleColumnA
     | FooterTitleColumnB
     | FooterTitleColumnC

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -6,7 +6,6 @@ import CookieBanner exposing (saveConsent)
 import GoogleAnalytics
 import Html.Styled exposing (Html, toUnstyled)
 import Http
-import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..))
 import Json.Decode
 import Message exposing (Msg(..))
@@ -203,6 +202,7 @@ view model =
 
         Story slug ->
             let
+                story : Page.Story.Data.Story
                 story =
                     Page.Story.Data.storyFromSlug model.language model.content.stories slug
             in
@@ -210,6 +210,7 @@ view model =
 
         Guide slug ->
             let
+                guide : Page.Guide.Data.Guide
                 guide =
                     Page.Guide.Data.guideFromSlug model.language model.content.guides slug
             in
@@ -220,6 +221,7 @@ view model =
 
         Page slug ->
             let
+                page : Page.Data.Page
                 page =
                     Page.Data.pageFromSlug model.language model.content.pages slug
             in

--- a/src/Page/Data.elm
+++ b/src/Page/Data.elm
@@ -1,4 +1,4 @@
-module Page.Data exposing (Page, Pages, pageFromSlug, pageLanguageDictDecoder, pageTitleFromSlug)
+module Page.Data exposing (Page, Pages, pageFromSlug, pageLanguageDictDecoder)
 
 import Dict exposing (Dict)
 import I18n.Keys exposing (Key(..))
@@ -86,13 +86,3 @@ pageFromSlug language pages slug =
 
                 Nothing ->
                     blankPage language
-
-
-pageTitleFromSlug : Dict String Page -> String -> String
-pageTitleFromSlug pages slug =
-    case Dict.get slug pages of
-        Just aPage ->
-            aPage.title
-
-        Nothing ->
-            ""

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -7,13 +7,13 @@ import Message exposing (Msg)
 import Page.Guide.Data
 import Page.GuideTeaser
 import Page.Shared.View
-import Theme.Global exposing (contentWrapper, mainInnerStyle, pageColumnBlockStyle, pageColumnStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (centerContent, contentWrapper, pageColumnBlockStyle, pageColumnStyle, topTwoColumnsWrapperStyle)
 import Theme.Markdown exposing (markdownToHtml)
 
 
 view : Page.Guide.Data.Guide -> Html Msg
 view guide =
-    div [ css [ mainInnerStyle ] ]
+    div [ css [ centerContent ] ]
         [ h1 [ css [ guideTitle ] ] [ text guide.title ]
         , div [ css [ contentWrapper ] ]
             [ div [ css [ topTwoColumnsWrapperStyle ] ]

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -1,19 +1,19 @@
 module Page.Guide.View exposing (view)
 
 import Css exposing (Style, batch, fontFamilies)
-import Html.Styled exposing (Html, a, div, h1, li, main_, text, ul)
+import Html.Styled exposing (Html, a, div, h1, li, text, ul)
 import Html.Styled.Attributes exposing (css, href)
 import Message exposing (Msg)
 import Page.Guide.Data
 import Page.GuideTeaser
 import Page.Shared.View
-import Theme.Global exposing (contentWrapper, mainContainerStyles, pageColumnBlockStyle, pageColumnStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (contentWrapper, mainInnerStyle, pageColumnBlockStyle, pageColumnStyle, topTwoColumnsWrapperStyle)
 import Theme.Markdown exposing (markdownToHtml)
 
 
 view : Page.Guide.Data.Guide -> Html Msg
 view guide =
-    main_ [ css [ mainContainerStyles ] ]
+    div [ css [ mainInnerStyle ] ]
         [ h1 [ css [ guideTitle ] ] [ text guide.title ]
         , div [ css [ contentWrapper ] ]
             [ div [ css [ topTwoColumnsWrapperStyle ] ]

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -1,21 +1,21 @@
 module Page.Guide.View exposing (view)
 
-import Css exposing (Style, fontFamilies)
-import Html.Styled exposing (Html, a, div, h1, li, text, ul)
+import Css exposing (Style, batch, fontFamilies)
+import Html.Styled exposing (Html, a, div, h1, li, main_, text, ul)
 import Html.Styled.Attributes exposing (css, href)
 import Message exposing (Msg)
 import Page.Guide.Data
 import Page.GuideTeaser
 import Page.Shared.View
-import Theme.Global exposing (centerContent, mainContainerStyles, pageColumnBlockStyle, pageColumnStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (contentWrapper, mainContainerStyles, pageColumnBlockStyle, pageColumnStyle, topTwoColumnsWrapperStyle)
 import Theme.Markdown exposing (markdownToHtml)
 
 
 view : Page.Guide.Data.Guide -> Html Msg
 view guide =
-    div [ css [ centerContent ] ]
-        [ h1 [ css guideTitle ] [ text guide.title ]
-        , div [ css [ mainContainerStyles ] ]
+    main_ [ css [ mainContainerStyles ] ]
+        [ h1 [ css [ guideTitle ] ] [ text guide.title ]
+        , div [ css [ contentWrapper ] ]
             [ div [ css [ topTwoColumnsWrapperStyle ] ]
                 [ div [ css [ pageColumnStyle ] ]
                     [ div [ css [ pageColumnBlockStyle ] ] (markdownToHtml guide.fullTextMarkdown) ]
@@ -69,7 +69,8 @@ viewRelatedGuideTeasers guideList =
         text ""
 
 
-guideTitle : List Style
+guideTitle : Style
 guideTitle =
-    [ fontFamilies [ "Ludicrous", "serif" ]
-    ]
+    batch
+        [ fontFamilies [ "Ludicrous", "serif" ]
+        ]

--- a/src/Page/GuideTeaser.elm
+++ b/src/Page/GuideTeaser.elm
@@ -1,4 +1,4 @@
-module Page.GuideTeaser exposing (GuideTeaser, Image, guideTeaserEncoder, guideTeaserListEncoder, guideTeaserListString)
+module Page.GuideTeaser exposing (GuideTeaser, Image, guideTeaserListEncoder, guideTeaserListString)
 
 import Json.Encode as Encode
 

--- a/src/Page/Guides.elm
+++ b/src/Page/Guides.elm
@@ -1,6 +1,6 @@
 module Page.Guides exposing (view)
 
-import Html.Styled exposing (Html, a, div, h1, li, main_, text)
+import Html.Styled exposing (Html, a, div, h1, li, text)
 import Html.Styled.Attributes exposing (class, css, href)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..), translate)
@@ -11,7 +11,7 @@ import Page.GuideTeaser
 import Page.Shared.View
 import Route
 import Shared exposing (Model, Request(..))
-import Theme.Global exposing (contentWrapper, mainContainerStyles)
+import Theme.Global exposing (contentWrapper, mainInnerStyle)
 
 
 view : Model -> Html Msg
@@ -39,7 +39,7 @@ view model =
                     Success list ->
                         List.concat [ Page.Guide.Data.teaserListFromGuideDict model.language model.content.guides, list ]
     in
-    main_ [ css [ mainContainerStyles ] ]
+    div [ css [ mainInnerStyle ] ]
         [ h1 []
             [ text (t GuidesTitle) ]
         , div

--- a/src/Page/Guides.elm
+++ b/src/Page/Guides.elm
@@ -47,9 +47,3 @@ view model =
             [ Page.Shared.View.viewGuideTeaserList teaserList
             ]
         ]
-
-
-guideCard : Guide -> Html Msg
-guideCard guide =
-    li [ class "guide-card" ]
-        [ a [ href (Route.toString (Route.Guide guide.slug)) ] [ text guide.title ] ]

--- a/src/Page/Guides.elm
+++ b/src/Page/Guides.elm
@@ -1,7 +1,6 @@
 module Page.Guides exposing (view)
 
-import Dict
-import Html.Styled exposing (Html, a, div, h1, li, text, ul)
+import Html.Styled exposing (Html, a, div, h1, li, main_, text)
 import Html.Styled.Attributes exposing (class, css, href)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..), translate)
@@ -12,7 +11,7 @@ import Page.GuideTeaser
 import Page.Shared.View
 import Route
 import Shared exposing (Model, Request(..))
-import Theme.Global exposing (centerContent)
+import Theme.Global exposing (contentWrapper, mainContainerStyles)
 
 
 view : Model -> Html Msg
@@ -40,9 +39,13 @@ view model =
                     Success list ->
                         List.concat [ Page.Guide.Data.teaserListFromGuideDict model.language model.content.guides, list ]
     in
-    div [ css [ centerContent ] ]
-        [ h1 [] [ text (t GuidesTitle) ]
-        , Page.Shared.View.viewGuideTeaserList teaserList
+    main_ [ css [ mainContainerStyles ] ]
+        [ h1 []
+            [ text (t GuidesTitle) ]
+        , div
+            [ css [ contentWrapper ] ]
+            [ Page.Shared.View.viewGuideTeaserList teaserList
+            ]
         ]
 
 

--- a/src/Page/Guides.elm
+++ b/src/Page/Guides.elm
@@ -11,7 +11,7 @@ import Page.GuideTeaser
 import Page.Shared.View
 import Route
 import Shared exposing (Model, Request(..))
-import Theme.Global exposing (contentWrapper, mainInnerStyle)
+import Theme.Global exposing (centerContent, contentWrapper)
 
 
 view : Model -> Html Msg
@@ -39,7 +39,7 @@ view model =
                     Success list ->
                         List.concat [ Page.Guide.Data.teaserListFromGuideDict model.language model.content.guides, list ]
     in
-    div [ css [ mainInnerStyle ] ]
+    div [ css [ centerContent ] ]
         [ h1 []
             [ text (t GuidesTitle) ]
         , div

--- a/src/Page/Guides.elm
+++ b/src/Page/Guides.elm
@@ -1,15 +1,14 @@
 module Page.Guides exposing (view)
 
-import Html.Styled exposing (Html, a, div, h1, li, text)
-import Html.Styled.Attributes exposing (class, css, href)
+import Html.Styled exposing (Html, div, h1, text)
+import Html.Styled.Attributes exposing (css)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..), translate)
 import List
 import Message exposing (Msg)
-import Page.Guide.Data exposing (Guide)
+import Page.Guide.Data
 import Page.GuideTeaser
 import Page.Shared.View
-import Route
 import Shared exposing (Model, Request(..))
 import Theme.Global exposing (centerContent, contentWrapper)
 
@@ -17,6 +16,7 @@ import Theme.Global exposing (centerContent, contentWrapper)
 view : Model -> Html Msg
 view model =
     let
+        t : Key -> String
         t =
             translate model.language
 

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -14,6 +14,7 @@ import Theme.Global exposing (centerContent, contentWrapper, pageColumnBlockStyl
 view : Model -> Html Msg
 view model =
     let
+        t : Key -> String
         t =
             translate model.language
     in

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -8,7 +8,7 @@ import Message exposing (Msg)
 import Page.Guide.Data
 import Page.Shared.View
 import Shared exposing (Model)
-import Theme.Global exposing (contentWrapper, mainInnerStyle, pageColumnBlockStyle, pageColumnStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (centerContent, contentWrapper, pageColumnBlockStyle, pageColumnStyle, topTwoColumnsWrapperStyle)
 
 
 view : Model -> Html Msg
@@ -17,7 +17,7 @@ view model =
         t =
             translate model.language
     in
-    div [ css [ mainInnerStyle, contentWrapper ] ]
+    div [ css [ centerContent, contentWrapper ] ]
         [ div [ css [ topTwoColumnsWrapperStyle ] ]
             [ div [ css [ pageColumnStyle ] ]
                 (viewTextColumn t [ WelcomeP1, WelcomeP2, WelcomeP3 ])

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -1,6 +1,6 @@
 module Page.Index exposing (view)
 
-import Html.Styled exposing (Html, div, p, text)
+import Html.Styled exposing (Html, div, main_, p, text)
 import Html.Styled.Attributes exposing (css)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (translate)
@@ -8,7 +8,7 @@ import Message exposing (Msg)
 import Page.Guide.Data
 import Page.Shared.View
 import Shared exposing (Model)
-import Theme.Global exposing (centerContent, mainContainerStyles, pageColumnBlockStyle, pageColumnStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (contentWrapper, mainContainerStyles, pageColumnBlockStyle, pageColumnStyle, topTwoColumnsWrapperStyle)
 
 
 view : Model -> Html Msg
@@ -17,24 +17,22 @@ view model =
         t =
             translate model.language
     in
-    div [ css [ centerContent ] ]
-        [ div [ css [ mainContainerStyles ] ]
-            [ div [ css [ topTwoColumnsWrapperStyle ] ]
-                [ div [ css [ pageColumnStyle ] ]
-                    (viewTextColumn t [ WelcomeP1, WelcomeP2, WelcomeP3 ])
-                , div [ css [ pageColumnStyle ] ]
-                    [ List.take 4 (Page.Guide.Data.teaserListFromGuideDict model.language model.content.guides)
-                        |> Page.Shared.View.viewGuideTeaserList
-                    ]
-                ]
+    main_ [ css [ mainContainerStyles, contentWrapper ] ]
+        [ div [ css [ topTwoColumnsWrapperStyle ] ]
+            [ div [ css [ pageColumnStyle ] ]
+                (viewTextColumn t [ WelcomeP1, WelcomeP2, WelcomeP3 ])
             , div [ css [ pageColumnStyle ] ]
-                (viewTextColumn t
-                    [ ExploreGuidesListPlaceholder
-                    , ExploreGuidesListPlaceholder
-                    , ExploreGuidesListPlaceholder
-                    ]
-                )
+                [ List.take 4 (Page.Guide.Data.teaserListFromGuideDict model.language model.content.guides)
+                    |> Page.Shared.View.viewGuideTeaserList
+                ]
             ]
+        , div [ css [ pageColumnStyle ] ]
+            (viewTextColumn t
+                [ ExploreGuidesListPlaceholder
+                , ExploreGuidesListPlaceholder
+                , ExploreGuidesListPlaceholder
+                ]
+            )
         ]
 
 

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -1,6 +1,6 @@
 module Page.Index exposing (view)
 
-import Html.Styled exposing (Html, div, main_, p, text)
+import Html.Styled exposing (Html, div, p, text)
 import Html.Styled.Attributes exposing (css)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (translate)
@@ -8,7 +8,7 @@ import Message exposing (Msg)
 import Page.Guide.Data
 import Page.Shared.View
 import Shared exposing (Model)
-import Theme.Global exposing (contentWrapper, mainContainerStyles, pageColumnBlockStyle, pageColumnStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (contentWrapper, mainInnerStyle, pageColumnBlockStyle, pageColumnStyle, topTwoColumnsWrapperStyle)
 
 
 view : Model -> Html Msg
@@ -17,7 +17,7 @@ view model =
         t =
             translate model.language
     in
-    main_ [ css [ mainContainerStyles, contentWrapper ] ]
+    div [ css [ mainInnerStyle, contentWrapper ] ]
         [ div [ css [ topTwoColumnsWrapperStyle ] ]
             [ div [ css [ pageColumnStyle ] ]
                 (viewTextColumn t [ WelcomeP1, WelcomeP2, WelcomeP3 ])

--- a/src/Page/Shared/View.elm
+++ b/src/Page/Shared/View.elm
@@ -1,7 +1,7 @@
 module Page.Shared.View exposing (AudioMeta, StoryTeaser, VideoMeta, actionTeaserDecoder, actionTeaserListDecoder, audioDecoder, defaultTeaserImg, guideTeaserDecoder, imageDecoder, interalGuideTeaserListDecoder, internalGuideTeaserDecoder, storyTeaserDecoder, videoDecoder, viewAudio, viewGuideTeaserList, viewStoryTeasers, viewVideo)
 
-import Css exposing (Style, backgroundImage, batch, center, column, displayFlex, flexDirection, flexWrap, height, justifyContent, listStyle, maxWidth, none, px, url, wrap)
-import Html.Styled exposing (Html, a, div, i, iframe, img, li, p, span, summary, text, ul)
+import Css exposing (Style, batch, center, column, displayFlex, flexDirection, flexWrap, height, justifyContent, maxWidth, px, url, wrap)
+import Html.Styled exposing (Html, a, div, i, iframe, img, li, p, summary, text, ul)
 import Html.Styled.Attributes exposing (alt, attribute, autoplay, css, href, src, title)
 import Json.Decode exposing (Decoder)
 import List exposing (map, sortBy)
@@ -117,7 +117,7 @@ viewVideo videoMeta =
 
 
 viewAudio : AudioMeta -> Html Msg
-viewAudio audioMeta =
+viewAudio _ =
     div
         [ css [ Theme.Global.embeddedVideoStyle ]
         ]

--- a/src/Page/Shared/View.elm
+++ b/src/Page/Shared/View.elm
@@ -1,14 +1,13 @@
 module Page.Shared.View exposing (AudioMeta, StoryTeaser, VideoMeta, actionTeaserDecoder, actionTeaserListDecoder, audioDecoder, defaultTeaserImg, guideTeaserDecoder, imageDecoder, interalGuideTeaserListDecoder, internalGuideTeaserDecoder, storyTeaserDecoder, videoDecoder, viewAudio, viewGuideTeaserList, viewStoryTeasers, viewVideo)
 
-import Css exposing (Style, batch, center, column, displayFlex, flexDirection, flexWrap, height, justifyContent, maxWidth, px, url, wrap)
-import Html.Styled exposing (Html, a, div, i, iframe, img, li, p, summary, text, ul)
+import Css exposing (Style, batch, center, column, displayFlex, flexDirection, flexWrap, height, justifyContent, maxWidth, px, wrap)
+import Html.Styled exposing (Html, a, div, iframe, img, li, p, text, ul)
 import Html.Styled.Attributes exposing (alt, attribute, autoplay, css, href, src, title)
 import Json.Decode exposing (Decoder)
 import List exposing (map, sortBy)
 import Message exposing (Msg)
 import Page.GuideTeaser
 import String exposing (length, padRight)
-import Svg.Styled exposing (image)
 import Theme.Global exposing (roundedCornerStyle, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle)
 
 

--- a/src/Page/Story/View.elm
+++ b/src/Page/Story/View.elm
@@ -1,17 +1,17 @@
 module Page.Story.View exposing (view)
 
-import Html.Styled exposing (Html, div, h1, img, main_, p, text)
+import Html.Styled exposing (Html, div, h1, img, p, text)
 import Html.Styled.Attributes exposing (alt, css, src)
 import Message exposing (Msg)
 import Page.Shared.View
 import Page.Story.Data
-import Theme.Global exposing (contentWrapper, featureImageStyle, mainContainerStyles, pageColumnStyle, roundedCornerStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (contentWrapper, featureImageStyle, mainInnerStyle, pageColumnStyle, roundedCornerStyle, topTwoColumnsWrapperStyle)
 import Theme.Markdown exposing (markdownToHtml)
 
 
 view : Page.Story.Data.Story -> Html Msg
 view story =
-    main_ [ css [ mainContainerStyles ] ]
+    div [ css [ mainInnerStyle ] ]
         [ h1 [] [ text story.title ]
         , div [ css [ contentWrapper ] ]
             [ div [ css [ topTwoColumnsWrapperStyle ] ]

--- a/src/Page/Story/View.elm
+++ b/src/Page/Story/View.elm
@@ -5,13 +5,13 @@ import Html.Styled.Attributes exposing (alt, css, src)
 import Message exposing (Msg)
 import Page.Shared.View
 import Page.Story.Data
-import Theme.Global exposing (contentWrapper, featureImageStyle, mainInnerStyle, pageColumnStyle, roundedCornerStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, pageColumnStyle, roundedCornerStyle, topTwoColumnsWrapperStyle)
 import Theme.Markdown exposing (markdownToHtml)
 
 
 view : Page.Story.Data.Story -> Html Msg
 view story =
-    div [ css [ mainInnerStyle ] ]
+    div [ css [ centerContent ] ]
         [ h1 [] [ text story.title ]
         , div [ css [ contentWrapper ] ]
             [ div [ css [ topTwoColumnsWrapperStyle ] ]

--- a/src/Page/Story/View.elm
+++ b/src/Page/Story/View.elm
@@ -1,19 +1,19 @@
 module Page.Story.View exposing (view)
 
-import Html.Styled exposing (Html, div, h1, img, p, text)
+import Html.Styled exposing (Html, div, h1, img, main_, p, text)
 import Html.Styled.Attributes exposing (alt, css, src)
 import Message exposing (Msg)
 import Page.Shared.View
 import Page.Story.Data
-import Theme.Global exposing (centerContent, featureImageStyle, mainContainerStyles, pageColumnStyle, roundedCornerStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (contentWrapper, featureImageStyle, mainContainerStyles, pageColumnStyle, roundedCornerStyle, topTwoColumnsWrapperStyle)
 import Theme.Markdown exposing (markdownToHtml)
 
 
 view : Page.Story.Data.Story -> Html Msg
 view story =
-    div [ css [ centerContent ] ]
+    main_ [ css [ mainContainerStyles ] ]
         [ h1 [] [ text story.title ]
-        , div [ css [ mainContainerStyles ] ]
+        , div [ css [ contentWrapper ] ]
             [ div [ css [ topTwoColumnsWrapperStyle ] ]
                 [ div [ css [ pageColumnStyle ] ]
                     [ div []

--- a/src/Page/View.elm
+++ b/src/Page/View.elm
@@ -1,16 +1,16 @@
 module Page.View exposing (view)
 
-import Html.Styled exposing (Html, div, h1, main_, text)
+import Html.Styled exposing (Html, div, h1, text)
 import Html.Styled.Attributes exposing (css)
 import Message exposing (Msg)
 import Page.Data
-import Theme.Global exposing (mainContainerStyles)
+import Theme.Global exposing (mainInnerStyle)
 import Theme.Markdown exposing (markdownToHtml)
 
 
 view : Page.Data.Page -> Html Msg
 view page =
-    main_ [ css [ mainContainerStyles ] ]
+    div [ css [ mainInnerStyle ] ]
         [ h1 [] [ text page.title ]
         , div [ css [] ] (markdownToHtml page.fullTextMarkdown)
         ]

--- a/src/Page/View.elm
+++ b/src/Page/View.elm
@@ -1,16 +1,16 @@
 module Page.View exposing (view)
 
-import Html.Styled exposing (Html, div, h1, text)
+import Html.Styled exposing (Html, div, h1, main_, text)
 import Html.Styled.Attributes exposing (css)
 import Message exposing (Msg)
 import Page.Data
-import Theme.Global exposing (centerContent)
+import Theme.Global exposing (contentWrapper, mainContainerStyles)
 import Theme.Markdown exposing (markdownToHtml)
 
 
 view : Page.Data.Page -> Html Msg
 view page =
-    div [ css [ centerContent ] ]
+    main_ [ css [ mainContainerStyles ] ]
         [ h1 [] [ text page.title ]
-        , div [] (markdownToHtml page.fullTextMarkdown)
+        , div [ css [] ] (markdownToHtml page.fullTextMarkdown)
         ]

--- a/src/Page/View.elm
+++ b/src/Page/View.elm
@@ -4,7 +4,7 @@ import Html.Styled exposing (Html, div, h1, main_, text)
 import Html.Styled.Attributes exposing (css)
 import Message exposing (Msg)
 import Page.Data
-import Theme.Global exposing (contentWrapper, mainContainerStyles)
+import Theme.Global exposing (mainContainerStyles)
 import Theme.Markdown exposing (markdownToHtml)
 
 

--- a/src/Page/View.elm
+++ b/src/Page/View.elm
@@ -12,5 +12,5 @@ view : Page.Data.Page -> Html Msg
 view page =
     div [ css [ centerContent ] ]
         [ h1 [] [ text page.title ]
-        , div [ css [] ] (markdownToHtml page.fullTextMarkdown)
+        , div [ ] (markdownToHtml page.fullTextMarkdown)
         ]

--- a/src/Page/View.elm
+++ b/src/Page/View.elm
@@ -4,13 +4,13 @@ import Html.Styled exposing (Html, div, h1, text)
 import Html.Styled.Attributes exposing (css)
 import Message exposing (Msg)
 import Page.Data
-import Theme.Global exposing (mainInnerStyle)
+import Theme.Global exposing (centerContent)
 import Theme.Markdown exposing (markdownToHtml)
 
 
 view : Page.Data.Page -> Html Msg
 view page =
-    div [ css [ mainInnerStyle ] ]
+    div [ css [ centerContent ] ]
         [ h1 [] [ text page.title ]
         , div [ css [] ] (markdownToHtml page.fullTextMarkdown)
         ]

--- a/src/Theme/FooterTemplate.elm
+++ b/src/Theme/FooterTemplate.elm
@@ -1,6 +1,6 @@
 module Theme.FooterTemplate exposing (view)
 
-import Css exposing (Style, alignItems, alignSelf, auto, backgroundColor, batch, border3, borderBox, borderLeft3, borderTop3, center, color, column, displayFlex, em, firstChild, fitContent, flexDirection, flexEnd, flexGrow, flexShrink, flexStart, flexWrap, fontFamilies, fontSize, height, int, justifyContent, lastChild, margin, margin2, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minHeight, minWidth, nthChild, outset, padding, padding2, paddingBottom, px, rem, row, solid, spaceBetween, unset, width, wrap)
+import Css exposing (Style, alignItems, alignSelf, auto, backgroundColor, batch, border3, borderLeft3, center, color, column, displayFlex, em, firstChild, fitContent, flexDirection, flexEnd, flexGrow, flexShrink, flexStart, flexWrap, fontFamilies, fontSize, height, int, justifyContent, lastChild, margin, margin2, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minHeight, minWidth, nthChild, padding, padding2, paddingBottom, px, rem, row, solid, spaceBetween, unset, width, wrap)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html, a, div, footer, h3, img, nav, text)
 import Html.Styled.Attributes exposing (css, href, src)

--- a/src/Theme/FooterTemplate.elm
+++ b/src/Theme/FooterTemplate.elm
@@ -1,6 +1,6 @@
 module Theme.FooterTemplate exposing (view)
 
-import Css exposing (Style, alignItems, alignSelf, auto, backgroundColor, batch, border3, borderLeft3, center, color, column, displayFlex, em, firstChild, fitContent, flexDirection, flexEnd, flexGrow, flexShrink, flexStart, flexWrap, fontFamilies, fontSize, height, int, justifyContent, lastChild, margin, margin2, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minHeight, minWidth, nthChild, padding, padding2, paddingBottom, px, rem, row, solid, spaceBetween, unset, width, wrap)
+import Css exposing (Style, alignItems, alignSelf, auto, backgroundColor, batch, border3, borderLeft3, borderTop, center, color, column, displayFlex, em, firstChild, fitContent, flexDirection, flexEnd, flexGrow, flexShrink, flexStart, flexWrap, fontFamilies, fontSize, height, int, justifyContent, lastChild, margin, margin2, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minHeight, minWidth, nthChild, padding, padding2, paddingBottom, px, rem, row, solid, spaceBetween, unset, width, wrap)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html, a, div, footer, h3, img, nav, text)
 import Html.Styled.Attributes exposing (css, href, src)
@@ -139,6 +139,7 @@ navBorderStyle : Style
 navBorderStyle =
     batch
         [ border3 (rem 0.5) solid teal
+        , borderTop (rem 0)
         , backgroundColor lightTeal
         ]
 

--- a/src/Theme/FooterTemplate.elm
+++ b/src/Theme/FooterTemplate.elm
@@ -1,12 +1,12 @@
 module Theme.FooterTemplate exposing (view)
 
-import Css exposing (Style, alignItems, alignSelf, auto, backgroundColor, batch, borderLeft3, center, color, column, displayFlex, em, firstChild, fitContent, flexDirection, flexEnd, flexGrow, flexShrink, flexStart, flexWrap, fontFamilies, fontSize, height, int, justifyContent, lastChild, margin, margin2, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minHeight, minWidth, nthChild, padding, padding2, paddingBottom, px, rem, row, solid, spaceAround, spaceBetween, unset, width, wrap)
+import Css exposing (Style, alignItems, alignSelf, auto, backgroundColor, batch, border3, borderBox, borderLeft3, borderTop3, center, color, column, displayFlex, em, firstChild, fitContent, flexDirection, flexEnd, flexGrow, flexShrink, flexStart, flexWrap, fontFamilies, fontSize, height, int, justifyContent, lastChild, margin, margin2, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minHeight, minWidth, nthChild, outset, padding, padding2, paddingBottom, px, rem, row, solid, spaceBetween, unset, width, wrap)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html, a, div, footer, h3, img, nav, text)
 import Html.Styled.Attributes exposing (css, href, src)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..), translate)
-import Theme.Global exposing (centerContent, lightTeal, purple, white, withMediaMobileUp, withMediaTabletPortraitUp)
+import Theme.Global exposing (centerContent, lightTeal, purple, teal, white, withMediaMobileUp, withMediaTabletPortraitUp)
 
 
 view : Language -> Html msg
@@ -16,12 +16,15 @@ view language =
         t =
             translate language
     in
-    footer []
-        [ nav [ css [ centerContent, footerNavStyle ] ]
-            (List.map
-                (\column -> navigationColumn column language)
-                footerNavigationContent
-            )
+    footer
+        []
+        [ div [ css [ navBorderStyle ] ]
+            [ nav [ css [ centerContent, footerNavStyle ] ]
+                (List.map
+                    (\column -> navigationColumn column language)
+                    footerNavigationContent
+                )
+            ]
         , div [ css [ bottomFooterOuterContainerStyle ] ]
             [ div [ css [ centerContent, bottomFooterContainerStyle ] ]
                 [ div [ css [ charityInfoStyle ] ]
@@ -108,8 +111,7 @@ footerColumnListStyle =
 footerNavStyle : Style
 footerNavStyle =
     batch
-        [ backgroundColor lightTeal
-        , displayFlex
+        [ displayFlex
         , flexDirection column
         , flexWrap wrap
         , justifyContent center
@@ -130,6 +132,14 @@ bottomFooterOuterContainerStyle =
     batch
         [ backgroundColor purple
         , color white
+        ]
+
+
+navBorderStyle : Style
+navBorderStyle =
+    batch
+        [ border3 (rem 0.5) solid teal
+        , backgroundColor lightTeal
         ]
 
 

--- a/src/Theme/FooterTemplate.elm
+++ b/src/Theme/FooterTemplate.elm
@@ -1,6 +1,6 @@
 module Theme.FooterTemplate exposing (view)
 
-import Css exposing (Style, alignItems, alignSelf, auto, backgroundColor, batch, borderLeft3, center, color, column, displayFlex, em, firstChild, fitContent, flexDirection, flexEnd, flexGrow, flexShrink, flexStart, flexWrap, fontFamilies, fontSize, height, int, justifyContent, lastChild, margin, margin2, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minHeight, minWidth, nthChild, padding, padding2, paddingBottom, px, rem, row, solid, spaceAround, unset, width, wrap)
+import Css exposing (Style, alignItems, alignSelf, auto, backgroundColor, batch, borderLeft3, center, color, column, displayFlex, em, firstChild, fitContent, flexDirection, flexEnd, flexGrow, flexShrink, flexStart, flexWrap, fontFamilies, fontSize, height, int, justifyContent, lastChild, margin, margin2, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minHeight, minWidth, nthChild, padding, padding2, paddingBottom, px, rem, row, solid, spaceAround, spaceBetween, unset, width, wrap)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html, a, div, footer, h3, img, nav, text)
 import Html.Styled.Attributes exposing (css, href, src)
@@ -119,7 +119,7 @@ footerNavStyle =
         , width (rem 20)
         , withMediaMobileUp
             [ flexDirection row
-            , justifyContent spaceAround
+            , justifyContent spaceBetween
             , width auto
             ]
         ]
@@ -139,7 +139,7 @@ bottomFooterContainerStyle =
         [ alignItems center
         , displayFlex
         , flexDirection column
-        , justifyContent center
+        , justifyContent spaceBetween
         , withMediaTabletPortraitUp
             [ alignItems flexStart
             , flexDirection row

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,4 +1,4 @@
-module Theme.Global exposing (centerContent, contentWrapper, embeddedAudioStyle, embeddedVideoStyle, featureImageStyle, globalStyles, lightTeal, mainInnerStyle, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
+module Theme.Global exposing (centerContent, contentWrapper, embeddedAudioStyle, embeddedVideoStyle, featureImageStyle, globalStyles, lightTeal, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
 
 import Css exposing (Color, Style, alignItems, auto, backgroundPosition, backgroundRepeat, backgroundSize, batch, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contentBox, cover, displayFlex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, int, justifyContent, lastChild, listStyle, margin, margin2, marginBottom, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, pct, property, px, rem, row, spaceBetween, width, wrap, zero)
 import Css.Global exposing (global, typeSelector)
@@ -118,6 +118,7 @@ globalStyles =
         , typeSelector "h1"
             [ fontFamilies [ "Adelle", "serif" ]
             , color purple
+            , width (pct 100)
             ]
         , typeSelector "h2"
             [ fontFamilies [ "Adelle", "serif" ]
@@ -255,6 +256,7 @@ centerContent =
         , boxSizing contentBox
         , displayFlex
         , flexDirection column
+        , margin auto
         , maxWidth (px maxSmallDesktop)
         , margin (rem 0)
         , padding2 (rem 2) (rem 1)
@@ -283,14 +285,6 @@ contentWrapper =
             [ alignItems flexStart
             , flexDirection row
             ]
-        ]
-
-
-mainInnerStyle : Style
-mainInnerStyle =
-    batch
-        [ centerContent
-        , margin auto
         ]
 
 

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,10 +1,9 @@
-module Theme.Global exposing (centerContent, contentWrapper, embeddedAudioStyle, embeddedVideoStyle, featureImageStyle, globalStyles, lightTeal, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
+module Theme.Global exposing (centerContent, contentWrapper, embeddedVideoStyle, featureImageStyle, globalStyles, lightTeal, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
 
 import Css exposing (Color, Style, alignItems, auto, backgroundPosition, backgroundRepeat, backgroundSize, batch, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contentBox, cover, displayFlex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, int, justifyContent, lastChild, listStyle, margin, margin2, marginBottom, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, pct, property, px, rem, row, spaceBetween, width, wrap, zero)
 import Css.Global exposing (global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html)
-import Markdown.Block exposing (Alignment(..))
 
 
 
@@ -233,15 +232,6 @@ teaserImageStyle =
 
 embeddedVideoStyle : Style
 embeddedVideoStyle =
-    batch
-        [ width (pct 100)
-        , height auto
-        , maxWidth (px (maxTabletLandscape / 3))
-        ]
-
-
-embeddedAudioStyle : Style
-embeddedAudioStyle =
     batch
         [ width (pct 100)
         , height auto

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -315,8 +315,7 @@ columnWidthStyle : Style
 columnWidthStyle =
     batch
         [ withMediaTabletPortraitUp
-            [ maxWidth (px (maxSmallDesktop / 3))
-            , minWidth (px (maxTabletPortrait / 3))
+            [ minWidth (px (maxTabletPortrait / 3))
             ]
         ]
 

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,26 +1,10 @@
-module Theme.Global exposing (centerContent, contentWrapper, embeddedAudioStyle, embeddedVideoStyle, featureImageStyle, globalStyles, lightTeal, mainContainerStyles, outerPadding, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
+module Theme.Global exposing (centerContent, contentWrapper, embeddedAudioStyle, embeddedVideoStyle, featureImageStyle, globalStyles, lightTeal, mainContainerStyles, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
 
-import Css exposing (Color, Style, absolute, alignItems, auto, backgroundPosition, backgroundRepeat, backgroundSize, batch, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, clip, color, column, contentBox, cover, displayFlex, fitContent, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, int, justifyContent, lastChild, left, listStyle, margin, margin2, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, paddingLeft, paddingRight, pct, position, property, px, rem, row, spaceBetween, top, width, wrap, zero)
-import Css.Global exposing (global, rect, typeSelector)
+import Css exposing (Color, Style, alignItems, auto, backgroundPosition, backgroundRepeat, backgroundSize, batch, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contentBox, cover, displayFlex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, int, justifyContent, lastChild, listStyle, margin, margin2, marginBottom, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, pct, property, px, rem, row, spaceBetween, width, wrap, zero)
+import Css.Global exposing (global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html)
 import Markdown.Block exposing (Alignment(..))
-
-
-
--- Accessibility helpers
-
-
-screenReaderOnly : Style
-screenReaderOnly =
-    batch
-        [ position absolute
-        , left (px -10000)
-        , top auto
-        , width (px 1)
-        , height (px 1)
-        , overflow hidden
-        ]
 
 
 
@@ -68,9 +52,7 @@ withMediaDesktopUp =
 
 
 
--- Brand colours
--- Accent colours
--- Text and background colours
+-- Colours
 
 
 purple : Color
@@ -266,19 +248,6 @@ embeddedAudioStyle =
         ]
 
 
-outerPadding : Style
-outerPadding =
-    batch
-        [ padding2 (rem 2) (rem 1)
-        , withMediaTabletPortraitUp
-            [ padding (rem 3)
-            ]
-        , withMediaTabletLandscapeUp
-            [ padding2 (rem 4) (rem 3)
-            ]
-        ]
-
-
 centerContent : Style
 centerContent =
     batch
@@ -288,8 +257,14 @@ centerContent =
         , flexDirection column
         , maxWidth (px maxSmallDesktop)
         , margin (rem 0)
-        , outerPadding
+        , padding2 (rem 2) (rem 1)
         , width auto
+        , withMediaTabletPortraitUp
+            [ padding (rem 3)
+            ]
+        , withMediaTabletLandscapeUp
+            [ padding2 (rem 4) (rem 3)
+            ]
         , withMediaDesktopUp
             [ margin2 (rem 0) auto
             ]
@@ -304,8 +279,6 @@ contentWrapper =
         , flexDirection column
         , flexWrap noWrap
         , justifyContent center
-
-        -- , width (pct 100)
         , withMediaTabletLandscapeUp
             [ alignItems flexStart
             , flexDirection row
@@ -386,7 +359,3 @@ pageColumnBlockStyle =
             [ marginBottom (rem 0)
             ]
         ]
-
-
-
--- Map

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,4 +1,4 @@
-module Theme.Global exposing (centerContent, contentWrapper, embeddedAudioStyle, embeddedVideoStyle, featureImageStyle, globalStyles, lightTeal, mainContainerStyles, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
+module Theme.Global exposing (centerContent, contentWrapper, embeddedAudioStyle, embeddedVideoStyle, featureImageStyle, globalStyles, lightTeal, mainInnerStyle, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
 
 import Css exposing (Color, Style, alignItems, auto, backgroundPosition, backgroundRepeat, backgroundSize, batch, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contentBox, cover, displayFlex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, int, justifyContent, lastChild, listStyle, margin, margin2, marginBottom, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, pct, property, px, rem, row, spaceBetween, width, wrap, zero)
 import Css.Global exposing (global, typeSelector)
@@ -286,8 +286,8 @@ contentWrapper =
         ]
 
 
-mainContainerStyles : Style
-mainContainerStyles =
+mainInnerStyle : Style
+mainInnerStyle =
     batch
         [ centerContent
         , margin auto

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,9 +1,10 @@
-module Theme.Global exposing (centerContent, embeddedAudioStyle, embeddedVideoStyle, featureImageStyle, globalStyles, lightTeal, mainContainerStyles, outerPadding, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
+module Theme.Global exposing (centerContent, contentWrapper, embeddedAudioStyle, embeddedVideoStyle, featureImageStyle, globalStyles, lightTeal, mainContainerStyles, outerPadding, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
 
-import Css exposing (Color, Style, absolute, alignItems, auto, backgroundPosition, backgroundRepeat, backgroundSize, batch, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, clip, color, column, contentBox, cover, displayFlex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, int, justifyContent, lastChild, left, listStyle, margin, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, pct, position, property, px, rem, row, spaceBetween, top, width, wrap, zero)
+import Css exposing (Color, Style, absolute, alignItems, auto, backgroundPosition, backgroundRepeat, backgroundSize, batch, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, clip, color, column, contentBox, cover, displayFlex, fitContent, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, int, justifyContent, lastChild, left, listStyle, margin, margin2, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, paddingLeft, paddingRight, pct, position, property, px, rem, row, spaceBetween, top, width, wrap, zero)
 import Css.Global exposing (global, rect, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html)
+import Markdown.Block exposing (Alignment(..))
 
 
 
@@ -59,6 +60,11 @@ withMediaTabletPortraitUp =
 withMediaTabletLandscapeUp : List Style -> Style
 withMediaTabletLandscapeUp =
     withMedia [ only screen [ Media.minWidth (px maxTabletLandscape) ] ]
+
+
+withMediaDesktopUp : List Style -> Style
+withMediaDesktopUp =
+    withMedia [ only screen [ Media.minWidth (px maxSmallDesktop) ] ]
 
 
 
@@ -170,11 +176,12 @@ teaserContainerStyle =
     batch
         [ alignItems flexStart
         , displayFlex
-        , flex3 (int 1) (int 1) (pct 34)
+        , flex3 (int 1) (int 1) (pct 20)
         , flexDirection column
         , listStyle none
         , marginRight (rem 1.5)
         , marginBottom (rem 1.5)
+        , maxWidth (px 180)
         , minWidth (px 120)
         , width (pct 100)
         , lastChild
@@ -182,7 +189,8 @@ teaserContainerStyle =
             , marginRight (rem 0)
             ]
         , withMediaTabletPortraitUp
-            [ minWidth (px 100)
+            [ flex3 (int 1) (int 1) (pct 34)
+            , minWidth (px 100)
             ]
         ]
 
@@ -193,6 +201,7 @@ teaserRowStyle =
         [ margin (rem 0)
         , marginBottom
             (rem 0.5)
+        , width inherit
         , lastChild
             [ marginBottom (rem 0)
             ]
@@ -206,9 +215,13 @@ teasersContainerStyle =
         , displayFlex
         , flexDirection row
         , flexWrap wrap
+        , justifyContent spaceBetween
         , margin (rem 0)
         , padding (rem 0)
-        , width (pct 100)
+        , width auto
+        , withMediaTabletPortraitUp
+            [ justifyContent flexStart
+            ]
         ]
 
 
@@ -274,23 +287,37 @@ centerContent =
         , displayFlex
         , flexDirection column
         , maxWidth (px maxSmallDesktop)
-        , marginLeft auto
-        , marginRight auto
+        , margin (rem 0)
         , outerPadding
+        , width auto
+        , withMediaDesktopUp
+            [ margin2 (rem 0) auto
+            ]
+        ]
+
+
+contentWrapper : Style
+contentWrapper =
+    batch
+        [ alignItems center
+        , displayFlex
+        , flexDirection column
+        , flexWrap noWrap
+        , justifyContent center
+
+        -- , width (pct 100)
+        , withMediaTabletLandscapeUp
+            [ alignItems flexStart
+            , flexDirection row
+            ]
         ]
 
 
 mainContainerStyles : Style
 mainContainerStyles =
     batch
-        [ alignItems flexStart
-        , displayFlex
-        , flexDirection column
-        , flexWrap noWrap
-        , justifyContent center
-        , withMediaTabletLandscapeUp
-            [ flexDirection row
-            ]
+        [ centerContent
+        , margin auto
         ]
 
 
@@ -303,7 +330,7 @@ topTwoColumnsWrapperStyle =
         , flexWrap noWrap
         , justifyContent center
         , marginBottom (rem 3)
-        , width (pct 100)
+        , width auto
         , withMediaTabletPortraitUp
             [ flex (int 2)
             , flexDirection row
@@ -330,10 +357,9 @@ pageColumnMarginStyle =
 columnWidthStyle : Style
 columnWidthStyle =
     batch
-        [ maxWidth (px (maxSmallDesktop / 3))
-        , width (pct 100)
-        , withMediaTabletPortraitUp
-            [ minWidth (px (maxTabletPortrait / 3))
+        [ withMediaTabletPortraitUp
+            [ maxWidth (px (maxSmallDesktop / 3))
+            , minWidth (px (maxTabletPortrait / 3))
             ]
         ]
 

--- a/src/Theme/HeaderTemplate.elm
+++ b/src/Theme/HeaderTemplate.elm
@@ -44,10 +44,10 @@ view model =
 viewSiteTitle : Route -> String -> Html Msg
 viewSiteTitle route siteTitle =
     if route == Index then
-        h1 [ css [ headerBrandStyle, headerTitleStyle, fixHeaderStyle ] ] [ text siteTitle ]
+        h1 [ css [ headerBrandStyle ] ] [ text siteTitle ]
 
     else
-        div [ css [ headerBrandStyle, headerTitleStyle ] ]
+        div [ css [ headerBrandStyle ] ]
             [ a
                 [ href "/"
                 , css
@@ -100,8 +100,12 @@ headerBrandStyle =
     batch
         [ fontSize (rem 4)
         , fontFamilies [ "Ludicrous" ]
+        , fontWeight normal
         , lineHeight (rem 4)
         , margin zero
+        , maxWidth (px 336)
+        , withMediaMobileUp
+            [ marginRight (rem 3) ]
         ]
 
 
@@ -148,15 +152,6 @@ headerLinkStyle =
         ]
 
 
-headerTitleStyle : Style
-headerTitleStyle =
-    batch
-        [ maxWidth (px 336)
-        , withMediaMobileUp
-            [ marginRight (rem 3) ]
-        ]
-
-
 searchStyle : Style
 searchStyle =
     batch
@@ -195,11 +190,4 @@ searchInputStyle =
             [ color purple
             , fontWeight (int 700)
             ]
-        ]
-
-
-fixHeaderStyle : Style
-fixHeaderStyle =
-    batch
-        [ fontWeight normal
         ]

--- a/src/Theme/HeaderTemplate.elm
+++ b/src/Theme/HeaderTemplate.elm
@@ -1,6 +1,6 @@
 module Theme.HeaderTemplate exposing (view)
 
-import Css exposing (Style, absolute, alignItems, auto, backgroundColor, baseline, batch, border3, borderRadius, bottom, boxShadow, center, color, column, displayFlex, flexDirection, flexEnd, flexStart, flexWrap, focus, fontFamilies, fontSize, fontWeight, height, int, justifyContent, left, lineHeight, margin, margin2, margin4, marginBottom, marginRight, marginTop, maxWidth, minWidth, noWrap, none, normal, outline, padding, padding3, padding4, pct, position, pseudoElement, px, relative, rem, right, row, solid, spaceBetween, textAlign, textDecoration, top, width, zero)
+import Css exposing (Style, absolute, alignItems, backgroundColor, baseline, batch, border3, borderRadius, bottom, boxShadow, center, color, column, displayFlex, flexDirection, flexEnd, flexStart, flexWrap, focus, fontFamilies, fontSize, fontWeight, height, int, justifyContent, left, lineHeight, margin, margin2, margin4, marginBottom, marginRight, marginTop, maxWidth, minWidth, noWrap, none, normal, outline, padding, padding4, pct, position, pseudoElement, px, relative, rem, right, row, solid, spaceBetween, textAlign, textDecoration, top, width, zero)
 import Html.Styled exposing (Html, a, button, div, h1, header, img, input, label, node, text)
 import Html.Styled.Attributes exposing (attribute, css, href, id, placeholder, property, src, type_)
 import Html.Styled.Events exposing (on, onClick)

--- a/src/Theme/HeaderTemplate.elm
+++ b/src/Theme/HeaderTemplate.elm
@@ -65,6 +65,7 @@ viewSiteTitle route siteTitle =
 searchInput : Model -> Html Msg
 searchInput model =
     let
+        t : Key -> String
         t =
             I18n.Translate.translate model.language
 

--- a/src/Theme/HeaderTemplate.elm
+++ b/src/Theme/HeaderTemplate.elm
@@ -1,6 +1,6 @@
 module Theme.HeaderTemplate exposing (view)
 
-import Css exposing (Style, absolute, alignItems, auto, baseline, batch, border3, borderRadius, bottom, boxShadow, center, color, column, displayFlex, flexDirection, flexEnd, flexStart, flexWrap, focus, fontFamilies, fontSize, fontWeight, height, int, justifyContent, left, lineHeight, margin, margin2, margin4, marginBottom, marginRight, marginTop, maxWidth, minWidth, noWrap, none, normal, outline, padding, padding3, padding4, pct, position, pseudoElement, px, relative, rem, right, row, solid, spaceBetween, textAlign, textDecoration, top, width, zero)
+import Css exposing (Style, absolute, alignItems, auto, backgroundColor, baseline, batch, border3, borderRadius, bottom, boxShadow, center, color, column, displayFlex, flexDirection, flexEnd, flexStart, flexWrap, focus, fontFamilies, fontSize, fontWeight, height, int, justifyContent, left, lineHeight, margin, margin2, margin4, marginBottom, marginRight, marginTop, maxWidth, minWidth, noWrap, none, normal, outline, padding, padding3, padding4, pct, position, pseudoElement, px, relative, rem, right, row, solid, spaceBetween, textAlign, textDecoration, top, width, zero)
 import Html.Styled exposing (Html, a, button, div, h1, header, img, input, label, node, text)
 import Html.Styled.Attributes exposing (attribute, css, href, id, placeholder, property, src, type_)
 import Html.Styled.Events exposing (on, onClick)
@@ -14,7 +14,7 @@ import Page.GuideTeaser
 import Page.Shared.View
 import Route exposing (Route(..))
 import Shared exposing (Model, Request(..))
-import Theme.Global exposing (centerContent, purple, withMediaMobileUp)
+import Theme.Global exposing (centerContent, purple, teal, white, withMediaMobileUp)
 
 
 view : Model -> Html Msg
@@ -24,18 +24,20 @@ view model =
         t =
             translate model.language
     in
-    header [ css [ centerContent ] ]
-        [ div [ css [ headerContainerStyle ] ]
-            [ viewSiteTitle model.page (t SiteTitle)
-            , div [ css [ searchButtonsContainerStyle ] ]
-                [ button [ onClick LanguageChangeRequested ]
-                    [ text (t ChangeLanguage) ]
-                , case model.page of
-                    Guides ->
-                        searchInput model
+    header [ css [ headerOuterStyle ] ]
+        [ div [ css [ centerContent ] ]
+            [ div [ css [ headerContainerStyle ] ]
+                [ viewSiteTitle model.page (t SiteTitle)
+                , div [ css [ searchButtonsContainerStyle ] ]
+                    [ button [ onClick LanguageChangeRequested ]
+                        [ text (t ChangeLanguage) ]
+                    , case model.page of
+                        Guides ->
+                            searchInput model
 
-                    _ ->
-                        a [ href "/guides", css [ headerLinkStyle ] ] [ text <| t FooterGuidesLinkText ]
+                        _ ->
+                            a [ href "/guides", css [ headerLinkStyle ] ] [ text <| t FooterGuidesLinkText ]
+                    ]
                 ]
             ]
         ]
@@ -51,7 +53,8 @@ viewSiteTitle route siteTitle =
             [ a
                 [ href "/"
                 , css
-                    [ textDecoration none
+                    [ color white
+                    , textDecoration none
                     ]
                 ]
                 [ text siteTitle
@@ -98,7 +101,8 @@ searchInput model =
 headerBrandStyle : Style
 headerBrandStyle =
     batch
-        [ fontSize (rem 4)
+        [ color white
+        , fontSize (rem 4)
         , fontFamilies [ "Ludicrous" ]
         , fontWeight normal
         , lineHeight (rem 4)
@@ -106,6 +110,14 @@ headerBrandStyle =
         , maxWidth (px 336)
         , withMediaMobileUp
             [ marginRight (rem 3) ]
+        ]
+
+
+headerOuterStyle : Style
+headerOuterStyle =
+    batch
+        [ backgroundColor teal
+        , color white
         ]
 
 
@@ -145,7 +157,8 @@ searchButtonsContainerStyle =
 headerLinkStyle : Style
 headerLinkStyle =
     batch
-        [ textAlign left
+        [ color white
+        , textAlign left
         , withMediaMobileUp
             [ textAlign right
             ]

--- a/src/Theme/HeaderTemplate.elm
+++ b/src/Theme/HeaderTemplate.elm
@@ -36,7 +36,7 @@ view model =
                             searchInput model
 
                         _ ->
-                            a [ href "/guides", css [ headerLinkStyle ] ] [ text <| t FooterGuidesLinkText ]
+                            a [ href (Route.toString Guides), css [ headerLinkStyle ] ] [ text (t FooterGuidesLinkText) ]
                     ]
                 ]
             ]

--- a/src/Theme/HeaderTemplate.elm
+++ b/src/Theme/HeaderTemplate.elm
@@ -1,6 +1,6 @@
 module Theme.HeaderTemplate exposing (view)
 
-import Css exposing (Style, absolute, alignItems, baseline, batch, border3, borderRadius, bottom, boxShadow, center, color, column, displayFlex, flexDirection, flexEnd, flexStart, flexWrap, focus, fontFamilies, fontSize, fontWeight, height, int, justifyContent, left, lineHeight, margin, margin2, margin4, marginBottom, marginRight, marginTop, maxWidth, minWidth, noWrap, none, normal, outline, padding, padding3, padding4, position, pseudoElement, px, relative, rem, right, row, solid, spaceBetween, textAlign, textDecoration, top, zero)
+import Css exposing (Style, absolute, alignItems, auto, baseline, batch, border3, borderRadius, bottom, boxShadow, center, color, column, displayFlex, flexDirection, flexEnd, flexStart, flexWrap, focus, fontFamilies, fontSize, fontWeight, height, int, justifyContent, left, lineHeight, margin, margin2, margin4, marginBottom, marginRight, marginTop, maxWidth, minWidth, noWrap, none, normal, outline, padding, padding3, padding4, pct, position, pseudoElement, px, relative, rem, right, row, solid, spaceBetween, textAlign, textDecoration, top, width, zero)
 import Html.Styled exposing (Html, a, button, div, h1, header, img, input, label, node, text)
 import Html.Styled.Attributes exposing (attribute, css, href, id, placeholder, property, src, type_)
 import Html.Styled.Events exposing (on, onClick)
@@ -14,7 +14,7 @@ import Page.GuideTeaser
 import Page.Shared.View
 import Route exposing (Route(..))
 import Shared exposing (Model, Request(..))
-import Theme.Global exposing (centerContent, outerPadding, purple, withMediaMobileUp)
+import Theme.Global exposing (centerContent, purple, withMediaMobileUp)
 
 
 view : Model -> Html Msg
@@ -24,17 +24,19 @@ view model =
         t =
             translate model.language
     in
-    header [ css [ headerContainerStyle ] ]
-        [ viewSiteTitle model.page (t SiteTitle)
-        , div [ css [ searchButtonsContainerStyle ] ]
-            [ button [ onClick LanguageChangeRequested ]
-                [ text (t ChangeLanguage) ]
-            , case model.page of
-                Guides ->
-                    searchInput model
+    header [ css [ centerContent ] ]
+        [ div [ css [ headerContainerStyle ] ]
+            [ viewSiteTitle model.page (t SiteTitle)
+            , div [ css [ searchButtonsContainerStyle ] ]
+                [ button [ onClick LanguageChangeRequested ]
+                    [ text (t ChangeLanguage) ]
+                , case model.page of
+                    Guides ->
+                        searchInput model
 
-                _ ->
-                    a [ href "/guides", css [ headerLinkStyle ] ] [ text <| t FooterGuidesLinkText ]
+                    _ ->
+                        a [ href "/guides", css [ headerLinkStyle ] ] [ text <| t FooterGuidesLinkText ]
+                ]
             ]
         ]
 
@@ -107,12 +109,11 @@ headerContainerStyle : Style
 headerContainerStyle =
     batch
         [ alignItems baseline
-        , centerContent
         , displayFlex
         , flexDirection column
         , flexWrap noWrap
         , justifyContent center
-        , outerPadding
+        , width (pct 100)
         , withMediaMobileUp
             [ flexDirection row
             , justifyContent spaceBetween

--- a/src/Theme/Markdown.elm
+++ b/src/Theme/Markdown.elm
@@ -1,13 +1,12 @@
 module Theme.Markdown exposing (markdownToHtml, markdownToView)
 
-import Css exposing (Style, absolute, batch, before, center, color, decimal, em, firstChild, fontSize, fontWeight, int, left, lineHeight, listStyle, listStyleType, marginBlockEnd, marginBlockStart, none, paddingLeft, position, property, relative, rem, textAlign, top)
+import Css exposing (Style, batch)
 import Html.Styled as Html
 import Html.Styled.Attributes as Attr exposing (css)
 import Markdown.Block as Block
 import Markdown.Html
 import Markdown.Parser
 import Markdown.Renderer
-import Theme.Global exposing (roundedCornerStyle)
 
 
 markdownToHtml : String -> List (Html.Html msg)
@@ -152,7 +151,7 @@ htmlRenderer =
                 )
     , html = Markdown.Html.oneOf []
     , codeBlock =
-        \{ body, language } ->
+        \{ body } ->
             Html.pre []
                 [ Html.code []
                     [ Html.text body

--- a/src/Theme/Markdown.elm
+++ b/src/Theme/Markdown.elm
@@ -1,4 +1,4 @@
-module Theme.Markdown exposing (markdownToHtml, markdownToView)
+module Theme.Markdown exposing (markdownToHtml)
 
 import Css exposing (Style, batch)
 import Html.Styled as Html
@@ -108,6 +108,7 @@ htmlRenderer =
                             case item of
                                 Block.ListItem task children ->
                                     let
+                                        checkbox : Html.Html msg
                                         checkbox =
                                             case task of
                                                 Block.NoTask ->
@@ -165,6 +166,7 @@ htmlRenderer =
     , tableHeaderCell =
         \maybeAlignment ->
             let
+                attrs : List (Html.Attribute msg)
                 attrs =
                     maybeAlignment
                         |> Maybe.map
@@ -187,6 +189,7 @@ htmlRenderer =
     , tableCell =
         \maybeAlignment ->
             let
+                attrs : List (Html.Attribute msg)
                 attrs =
                     maybeAlignment
                         |> Maybe.map

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -1,14 +1,13 @@
 module Theme.PageTemplate exposing (view)
 
 import CookieBanner
-import Css exposing (Style, backgroundColor, batch, hidden, overflowX, pct, width)
-import Html.Styled exposing (Html, div)
+import Css exposing (Style, backgroundColor, batch, border3, hidden, overflowX, pct, rem, solid, width)
+import Html.Styled exposing (Html, div, main_)
 import Html.Styled.Attributes exposing (css)
-import I18n.Keys exposing (Key(..))
 import Message exposing (Msg(..))
 import Shared exposing (Model)
 import Theme.FooterTemplate as FooterTemplate
-import Theme.Global exposing (globalStyles, lightTeal)
+import Theme.Global exposing (globalStyles, lightTeal, teal)
 import Theme.HeaderTemplate as HeaderTemplate
 
 
@@ -19,7 +18,9 @@ view model content =
         , div
             [ css [ pageWrapperStyles ] ]
             [ HeaderTemplate.view model
-            , content
+            , main_ [ css [ mainContainerStyles ] ]
+                [ content
+                ]
             , FooterTemplate.view model.language
             , CookieBanner.viewCookieBanner model.language model.cookieState
             ]
@@ -29,7 +30,14 @@ view model content =
 pageWrapperStyles : Style
 pageWrapperStyles =
     batch
-        [ backgroundColor lightTeal
-        , overflowX hidden
+        [ overflowX hidden
         , width (pct 100)
+        ]
+
+
+mainContainerStyles : Style
+mainContainerStyles =
+    batch
+        [ border3 (rem 0.5) solid teal
+        , backgroundColor lightTeal
         ]

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -8,7 +8,7 @@ import I18n.Keys exposing (Key(..))
 import Message exposing (Msg(..))
 import Shared exposing (Model)
 import Theme.FooterTemplate as FooterTemplate
-import Theme.Global exposing (centerContent, globalStyles, lightTeal, mainContainerStyles)
+import Theme.Global exposing (globalStyles, lightTeal)
 import Theme.HeaderTemplate as HeaderTemplate
 
 

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -4,7 +4,7 @@ import CookieBanner
 import Css exposing (Style, backgroundColor, batch, border3, hidden, overflowX, pct, rem, solid, width)
 import Html.Styled exposing (Html, div, main_)
 import Html.Styled.Attributes exposing (css)
-import Message exposing (Msg(..))
+import Message exposing (Msg)
 import Shared exposing (Model)
 import Theme.FooterTemplate as FooterTemplate
 import Theme.Global exposing (globalStyles, lightTeal, teal)

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -2,7 +2,7 @@ module Theme.PageTemplate exposing (view)
 
 import CookieBanner
 import Css exposing (Style, backgroundColor, batch, hidden, overflowX, pct, width)
-import Html.Styled exposing (Html, div, main_)
+import Html.Styled exposing (Html, div)
 import Html.Styled.Attributes exposing (css)
 import I18n.Keys exposing (Key(..))
 import Message exposing (Msg(..))
@@ -19,9 +19,7 @@ view model content =
         , div
             [ css [ pageWrapperStyles ] ]
             [ HeaderTemplate.view model
-            , main_ [ css [ mainContainerStyles ] ]
-                [ content
-                ]
+            , content
             , FooterTemplate.view model.language
             , CookieBanner.viewCookieBanner model.language model.cookieState
             ]

--- a/tests/API.elm
+++ b/tests/API.elm
@@ -3,7 +3,7 @@ module API exposing (..)
 import Expect exposing (equal)
 import Json.Decode
 import Page.GuideTeaser exposing (guideTeaserListString)
-import Page.Shared.View exposing (actionTeaserDecoder, actionTeaserListDecoder, interalGuideTeaserListDecoder, internalGuideTeaserDecoder)
+import Page.Shared.View exposing (actionTeaserDecoder, actionTeaserListDecoder, interalGuideTeaserListDecoder)
 import Test exposing (Test, describe, test)
 import TestData exposing (..)
 

--- a/tests/API.elm
+++ b/tests/API.elm
@@ -1,11 +1,11 @@
-module API exposing (..)
+module API exposing (suite)
 
 import Expect exposing (equal)
 import Json.Decode
 import Page.GuideTeaser exposing (guideTeaserListString)
 import Page.Shared.View exposing (actionTeaserDecoder, actionTeaserListDecoder, interalGuideTeaserListDecoder)
 import Test exposing (Test, describe, test)
-import TestData exposing (..)
+import TestData exposing (actionsAPI, singleActionFromAPI, teaserFromResult, teaserFromResult2)
 
 
 suite : Test
@@ -30,6 +30,7 @@ suite =
         , test "internalGuideTeaserListDecoder works with encoded json" <|
             \_ ->
                 let
+                    json : String
                     json =
                         guideTeaserListString [ teaserFromResult, teaserFromResult2 ]
                 in

--- a/tests/Guide.elm
+++ b/tests/Guide.elm
@@ -8,7 +8,7 @@ import Page.Guide.View exposing (view)
 import Page.Shared.View exposing (defaultTeaserImg)
 import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
-import Test.Html.Selector exposing (classes, tag, text)
+import Test.Html.Selector exposing (tag, text)
 import TestUtils exposing (queryFromStyledHtml)
 
 

--- a/tests/Guide.elm
+++ b/tests/Guide.elm
@@ -2,9 +2,10 @@ module Guide exposing (suite)
 
 import Html
 import Html.Attributes
-import I18n.Keys exposing (Key(..))
+import Html.Styled
+import Message
 import Page.Guide.Data exposing (Guide)
-import Page.Guide.View exposing (view)
+import Page.Guide.View
 import Page.Shared.View exposing (defaultTeaserImg)
 import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
@@ -71,6 +72,7 @@ suite =
                 ]
             }
 
+        view : Guide -> Html.Styled.Html Message.Msg
         view =
             Page.Guide.View.view
     in

--- a/tests/Page.elm
+++ b/tests/Page.elm
@@ -1,7 +1,8 @@
 module Page exposing (suite)
 
 import Html
-import I18n.Keys exposing (Key(..))
+import Html.Styled
+import Message
 import Page.Data
 import Page.View
 import Test exposing (Test, describe, test)
@@ -20,6 +21,7 @@ suite =
             , fullTextMarkdown = "# Some markdown\n\nA small paragraph."
             }
 
+        view : Page.Data.Page -> Html.Styled.Html Message.Msg
         view =
             Page.View.view
     in

--- a/tests/Story.elm
+++ b/tests/Story.elm
@@ -2,10 +2,11 @@ module Story exposing (suite)
 
 import Html
 import Html.Attributes
-import I18n.Keys exposing (Key(..))
+import Html.Styled
+import Message
 import Page.Shared.View exposing (defaultTeaserImg)
 import Page.Story.Data exposing (Story)
-import Page.Story.View exposing (view)
+import Page.Story.View
 import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (tag, text)
@@ -48,6 +49,7 @@ suite =
                 ]
             }
 
+        view : Story -> Html.Styled.Html Message.Msg
         view =
             Page.Story.View.view
     in

--- a/tests/TestData.elm
+++ b/tests/TestData.elm
@@ -1,4 +1,4 @@
-module TestData exposing (..)
+module TestData exposing (actionsAPI, singleActionFromAPI, teaserFromResult, teaserFromResult2)
 
 import Page.GuideTeaser
 


### PR DESCRIPTION
Fixes #163 
Fixes #170 

## Description

- Nudges all the different pieces back into place and attempts to clean up some of the css decisions made along the way
- Removes unused classes & merges some separate styles for clarity
- Removes content-centering abilites from parent containers and pushes it into the top of each individual component. This stops everything from being out of whack width-wise, and allows background colours & borders to fill the screen
- Updates all the background and border colors (that I could think of - probably some more in there somewhere)

I also ran the linter which will make this hideous to review. Sorry everyone! 

## Notes

Individual Guide & Story pages still need a little TLC - maybe we should standardise our examples now and then we can make sure they look good with all the content - am noticing some weirdness around teaser image sizing on stories and the guide with images in it is going a bit bonkers, although it looks like this is maybe because the guide has an image in the markdown - is this something we expect as a possibility, or will they all just be imported as a gallery? 

@geeksforsocialchange/developers
