### PR TITLE
Remove summary from home and story page teasers

### DIFF
--- a/src/Page/Guides.elm
+++ b/src/Page/Guides.elm
@@ -44,6 +44,6 @@ view model =
             [ text (t GuidesTitle) ]
         , div
             [ css [ contentWrapper ] ]
-            [ Page.Shared.View.viewGuideTeaserList teaserList
+            [ Page.Shared.View.viewGuideTeaserList True teaserList
             ]
         ]

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -24,7 +24,7 @@ view model =
                 (viewTextColumn t [ WelcomeP1, WelcomeP2, WelcomeP3 ])
             , div [ css [ pageColumnStyle ] ]
                 [ List.take 4 (Page.Guide.Data.teaserListFromGuideDict model.language model.content.guides)
-                    |> Page.Shared.View.viewGuideTeaserList
+                    |> Page.Shared.View.viewGuideTeaserList False
                 ]
             ]
         , div [ css [ pageColumnStyle ] ]

--- a/src/Page/Shared/View.elm
+++ b/src/Page/Shared/View.elm
@@ -137,12 +137,14 @@ limitContent summary limit =
 defaultTeaserImg : Page.GuideTeaser.Image
 defaultTeaserImg =
     { src = "/images/wildlife-trust-logo.png"
-    , alt = "[cCc] back up alt text for defualt image"
+
+    -- If it's a placeholder, alt probably not meaningful
+    , alt = ""
     }
 
 
-viewGuideTeaser : Page.GuideTeaser.GuideTeaser -> Html Msg
-viewGuideTeaser teaser =
+viewGuideTeaser : Bool -> Page.GuideTeaser.GuideTeaser -> Html Msg
+viewGuideTeaser includeSummary teaser =
     let
         image : Page.GuideTeaser.Image
         image =
@@ -165,7 +167,11 @@ viewGuideTeaser teaser =
             []
         , p [ css [ teaserRowStyle ] ]
             [ a [ href teaser.url ] [ text teaser.title ] ]
-        , viewGuideTeaserSummary teaser.summary
+        , if includeSummary then
+            viewGuideTeaserSummary teaser.summary
+
+          else
+            text ""
         ]
 
 
@@ -180,14 +186,14 @@ viewGuideTeaserSummary summary =
         text ""
 
 
-viewGuideTeaserList : List Page.GuideTeaser.GuideTeaser -> Html Msg
-viewGuideTeaserList teasers =
+viewGuideTeaserList : Bool -> List Page.GuideTeaser.GuideTeaser -> Html Msg
+viewGuideTeaserList includeSummary teasers =
     if List.length teasers > 0 then
         ul [ css [ teasersContainerStyle ] ]
             (teasers
                 |> sortBy .title
                 |> map
-                    (\teaser -> viewGuideTeaser teaser)
+                    (\teaser -> viewGuideTeaser includeSummary teaser)
             )
 
     else

--- a/src/Page/Story/View.elm
+++ b/src/Page/Story/View.elm
@@ -42,7 +42,7 @@ view story =
                 , div [ css [ pageColumnStyle ] ]
                     (markdownToHtml story.fullTextMarkdown)
                 ]
-            , viewColumnWrapper (Page.Shared.View.viewGuideTeaserList story.relatedGuideList)
+            , viewColumnWrapper (Page.Shared.View.viewGuideTeaserList False story.relatedGuideList)
             ]
         ]
 


### PR DESCRIPTION
Fixes #210 

## Description

- Do not display summary of guides on homepage

@geeksforsocialchange/developers
