### PR TITLE
Make related fields optional

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -138,6 +138,7 @@ collections:
         search_fields: ["title", "summary"]
         value_field: "title"
         display_fields: ["title"]
+        required: false
         i18n: false
       - label: "Related Stories"
         name: "relatedStories"
@@ -147,6 +148,7 @@ collections:
         search_fields: ["title", "summary"]
         value_field: "title"
         display_fields: ["title"]
+        required: false
         i18n: false
   - name: "pages"
     label: "Pages"


### PR DESCRIPTION
Fixes #226 

## Description

- Make related fields optional

@geeksforsocialchange/developers

Decoder already provides a default: 
![image](https://github.com/geeksforsocialchange/teamwilder/assets/861172/5ef357db-4d11-444e-8457-61c9030d5c1a)
