### PR TITLE
Prevent husky from linting markdown

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,3 +14,5 @@ package-lock.json
 # build files
 dist
 
+#cms generated files
+content

--- a/package.json
+++ b/package.json
@@ -29,7 +29,5 @@
   },
   "dependencies": {
     "fuse.js": "^6.6.2"
-  },
-  "lint-staged": {
-    "ignore": ["content"]  }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -29,5 +29,7 @@
   },
   "dependencies": {
     "fuse.js": "^6.6.2"
-  }
+  },
+  "lint-staged": {
+    "ignore": ["content"]  }
 }


### PR DESCRIPTION
Fixes #280

## Description

- Stop the pre commit hook from linting content generated by users in the cms
- This is to stop automated changes from being made that have not been reviewed by the user who has created them - too much risk of removing/accidentally reformatting content in a way that was not intended and cannot be verified by the developer

@geeksforsocialchange/developers
