### PR TITLE
Stop end users from creating new pages

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -153,7 +153,7 @@ collections:
   - name: "pages"
     label: "Pages"
     folder: "content/pages"
-    create: true
+    create: false
     slug: "{{slug}}"
     i18n: true
     fields:


### PR DESCRIPTION
Fixes #251 

## Description

Pages (like about and privacy policy) should not be arbitrarily creatable. Although the front end does not support them the CMS does and could be confusing to content administrators.

@geeksforsocialchange/developers
