### PR TITLE
Decode captions and credits for stories

### DIFF
--- a/content/stories/en/test-story-with-maximal-fields.md
+++ b/content/stories/en/test-story-with-maximal-fields.md
@@ -1,0 +1,25 @@
+---
+title: Test story with maximal fields
+who: Test group
+location: In the United Kingdom
+images: 
+  - src: "/images/default-story-image.jpg"
+    alt: "alt text"
+    credit: "Test person"
+    caption: "This a test caption containing a lovely long description about this image, and all of the people and things in it, and the colours and the patterns and where it is and what they are all doing"
+  - src: "/images/default-story-image.jpg"
+    alt: "alt text"
+    caption: "Tiny test caption"
+summary: This is test story content, generated to populate the site before real
+  content goes in.
+---
+
+## My story
+
+A test story full of inspiration.
+
+[cCc] Marked so we catch in a sweep.
+
+Lorem ipsum dolor sit amet consectetur adipiscing elit dictumst odio class mauris, nascetur curae pellentesque laoreet nullam hac nisl ante lobortis posuere, malesuada hendrerit pharetra curabitur mus quam dapibus convallis condimentum suscipit. Fusce pretium non sociosqu sem himenaeos rutrum turpis praesent laoreet fermentum, viverra mollis cursus suspendisse vel suscipit id quisque magna, aliquam eget neque et etiam metus montes blandit feugiat. Torquent ante odio suspendisse sagittis leo ullamcorper facilisis mattis nostra faucibus, donec aliquet integer ad quam sed sodales sociosqu bibendum tempor, posuere massa volutpat condimentum felis neque nisl interdum elementum.
+
+Ac dapibus mauris faucibus tortor feugiat odio massa dis elementum, aliquam sed congue ornare sodales molestie integer id nostra class, volutpat commodo euismod morbi mi maecenas sagittis litora. Nostra massa aenean faucibus turpis fames ante ornare netus mauris potenti parturient, commodo luctus ultrices placerat lacus feugiat vitae eu sociis. Mollis magnis tincidunt tempor curabitur natoque torquent auctor per netus sodales facilisi, aenean mus class eleifend lectus vulputate tristique habitant dictum vel condimentum, nulla id senectus morbi diam hendrerit sapien elementum donec blandit.

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -197,11 +197,15 @@ viewStoryImage maybeImage =
                 Just anImage ->
                     { alt = anImage.alt
                     , src = anImage.src
+                    , maybeCaption = anImage.maybeCaption
+                    , maybeCredit = anImage.maybeCredit
                     }
 
                 Nothing ->
                     { alt = ""
                     , src = Page.Story.Data.defaultStoryImageSrc
+                    , maybeCaption = Nothing
+                    , maybeCredit = Nothing
                     }
     in
     img

--- a/src/Page/Story/Data.elm
+++ b/src/Page/Story/Data.elm
@@ -29,6 +29,8 @@ type alias Story =
 type alias Image =
     { alt : String
     , src : String
+    , maybeCaption : Maybe String
+    , maybeCredit : Maybe String
     }
 
 
@@ -88,9 +90,11 @@ storyDictDecoder =
 
 imageDecoder : Json.Decode.Decoder Image
 imageDecoder =
-    Json.Decode.map2 Image
+    Json.Decode.map4 Image
         (Json.Decode.field "alt" Json.Decode.string)
         (Json.Decode.field "src" Json.Decode.string)
+        (Json.Decode.maybe (Json.Decode.field "caption" Json.Decode.string))
+        (Json.Decode.maybe (Json.Decode.field "credit" Json.Decode.string))
 
 
 storyLanguageDictDecoder : Json.Decode.Decoder Stories

--- a/src/Page/Story/View.elm
+++ b/src/Page/Story/View.elm
@@ -1,5 +1,6 @@
 module Page.Story.View exposing (view)
 
+import Css exposing (Style, batch, margin3, rem)
 import Html.Styled exposing (Html, div, h1, img, p, text)
 import Html.Styled.Attributes exposing (alt, css, src)
 import Message exposing (Msg)
@@ -43,9 +44,20 @@ view story =
 viewImages : List Page.Story.Data.Image -> List (Html Msg)
 viewImages imageList =
     List.map
-        (\image -> img [ src image.src, alt image.alt, css [ roundedCornerStyle, featureImageStyle ] ] [])
+        (\image ->
+            div []
+                [ img [ src image.src, alt image.alt, css [ roundedCornerStyle, featureImageStyle ] ] []
+                , viewImageCaption (maybeCaptions image.maybeCaption image.maybeCredit)
+                ]
+        )
         (if List.length imageList == 0 then
-            imageList ++ [ { alt = "", src = Page.Story.Data.defaultStoryImageSrc } ]
+            imageList
+                ++ [ { alt = ""
+                     , src = Page.Story.Data.defaultStoryImageSrc
+                     , maybeCaption = Nothing
+                     , maybeCredit = Nothing
+                     }
+                   ]
 
          else
             imageList
@@ -60,3 +72,47 @@ viewColumnWrapper content =
 
     else
         text ""
+
+
+maybeCaptions : Maybe String -> Maybe String -> Maybe String
+maybeCaptions maybeImageCaption maybeImageCredit =
+    case maybeImageCredit of
+        Just anImageCredit ->
+            case maybeImageCaption of
+                Just anImageCaption ->
+                    let
+                        concatenator =
+                            if
+                                String.endsWith "." anImageCaption
+                                    || String.endsWith "!" anImageCaption
+                                    || String.endsWith "?" anImageCaption
+                            then
+                                ""
+
+                            else
+                                "."
+                    in
+                    Just (String.concat [ anImageCaption, concatenator, " Image credit: ", anImageCredit ])
+
+                Nothing ->
+                    Just (String.concat [ "Image credit: ", anImageCredit ])
+
+        Nothing ->
+            maybeImageCaption
+
+
+viewImageCaption : Maybe String -> Html Msg
+viewImageCaption maybeCaption =
+    case maybeCaption of
+        Just aCaption ->
+            div [ css [ imageCaptionStyle ] ]
+                [ text aCaption ]
+
+        Nothing ->
+            text ""
+
+
+imageCaptionStyle : Style
+imageCaptionStyle =
+    batch
+        [ margin3 (rem 0) (rem 0) (rem 1) ]


### PR DESCRIPTION
Fixes #201

## Description

- Decodes optional captions and credits for stories and adds one more test file for checking behaviour works

## Notes

I don't *love* that the string concatenation logic is happening in the view as it doesn't feel strictly presentational (although maybe it arguably is?) but it is taking me too long to figure out how to handle this logic while decoding the json so I have gone with it. If anyone has a better idea about how to handle this let me know!

@geeksforsocialchange/developers
