### PR TITLE
Import css reset

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,4 +1,4 @@
-import reset from "/src/css/reset.css?inline";
+import "/src/css/reset.css";
 import { Elm } from "/src/Main.elm";
 import SearchInput from "/src/js/search";
 


### PR DESCRIPTION
Fixes #263 

## Description

- stops vite from disabling css injection when importing css reset
