### PR TITLE
Update title for homepage 

### DIFF
--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -118,6 +118,9 @@ enStrings key =
         ---
         -- Index page
         ---
+        HomeTitle ->
+            "Welcome to the nextdoor nature hub"
+
         WelcomeP1 ->
             "[cCc] Nextdoor Nature is an initiative launched by the Wilidlife Trusts in 2022. (Read more here) The aim of Nextdoor Nature is to equip everyone with the skills and knowledge they need to make a positive difference for nature - in their own area, and beyond."
 

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -37,6 +37,7 @@ type Key
     | CookieDeclineButtonText
     | CookieSettingsButtonText
       --- Index Page
+    | HomeTitle
     | WelcomeP1
     | WelcomeP2
     | WelcomeP3

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -1,6 +1,6 @@
 module Page.Guide.View exposing (view)
 
-import Css exposing (Style, batch, center, column, displayFlex, flexDirection, flexWrap, fontFamilies, justifyContent, listStyle, marginTop, maxWidth, none, paddingLeft, px, wrap, zero)
+import Css exposing (Style, batch, center, column, displayFlex, flexDirection, flexWrap, fontFamilies, justifyContent, listStyle, marginTop, maxWidth, none, padding2, paddingLeft, px, wrap, zero)
 import Html.Styled exposing (Html, a, div, h1, h2, img, li, text, ul)
 import Html.Styled.Attributes exposing (alt, css, href, src)
 import I18n.Keys exposing (Key(..))

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -1,6 +1,6 @@
 module Page.Index exposing (view)
 
-import Html.Styled exposing (Html, div, p, text)
+import Html.Styled exposing (Html, div, h1, p, text)
 import Html.Styled.Attributes exposing (css)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (translate)
@@ -18,22 +18,26 @@ view model =
         t =
             translate model.language
     in
-    div [ css [ centerContent, contentWrapper ] ]
-        [ div [ css [ topTwoColumnsWrapperStyle ] ]
-            [ div [ css [ pageColumnStyle ] ]
-                (viewTextColumn t [ WelcomeP1, WelcomeP2, WelcomeP3 ])
+    div [ css [ centerContent ] ]
+        [ h1 []
+            [ text (t HomeTitle) ]
+        , div [ css [ contentWrapper ] ]
+            [ div [ css [ topTwoColumnsWrapperStyle ] ]
+                [ div [ css [ pageColumnStyle ] ]
+                    (viewTextColumn t [ WelcomeP1, WelcomeP2, WelcomeP3 ])
+                , div [ css [ pageColumnStyle ] ]
+                    [ List.take 4 (Page.Guides.Data.teaserListFromGuideDict model.language model.content.guides)
+                        |> Page.Guides.View.viewGuideTeaserList False
+                    ]
+                ]
             , div [ css [ pageColumnStyle ] ]
-                [ List.take 4 (Page.Guides.Data.teaserListFromGuideDict model.language model.content.guides)
-                    |> Page.Guides.View.viewGuideTeaserList False
-                ]
+                (viewTextColumn t
+                    [ ExploreGuidesListPlaceholder
+                    , ExploreGuidesListPlaceholder
+                    , ExploreGuidesListPlaceholder
+                    ]
+                )
             ]
-        , div [ css [ pageColumnStyle ] ]
-            (viewTextColumn t
-                [ ExploreGuidesListPlaceholder
-                , ExploreGuidesListPlaceholder
-                , ExploreGuidesListPlaceholder
-                ]
-            )
         ]
 
 

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,6 +1,6 @@
-module Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, globalStyles, lightTeal, listStyleNone, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
+module Theme.Global exposing (borderWrapper, centerContent, contentWrapper, featureImageStyle, globalStyles, lightTeal, listStyleNone, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
 
-import Css exposing (Color, Style, alignItems, auto, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contain, contentBox, cover, cursor, display, displayFlex, em, ex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, inlineBlock, int, justifyContent, lastChild, listStyle, margin, margin2, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, paddingLeft, pct, pointer, property, pseudoElement, px, rem, row, spaceBetween, textDecoration, url, width, wrap, zero)
+import Css exposing (Color, Style, alignItems, auto, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, border3, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contain, contentBox, cover, cursor, display, displayFlex, em, ex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, inlineBlock, int, justifyContent, lastChild, listStyle, margin, margin2, margin3, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, paddingLeft, pct, pointer, property, pseudoElement, px, rem, row, solid, spaceBetween, textDecoration, url, width, wrap, zero)
 import Css.Global exposing (global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html)
@@ -118,6 +118,7 @@ globalStyles =
         , typeSelector "h1"
             [ fontFamilies [ "Adelle", "serif" ]
             , color purple
+            , margin3 (rem 0) auto (rem 2)
             , Theme.FluidScale.fontSize4
             , width (pct 100)
             ]
@@ -271,17 +272,11 @@ centerContent =
         , flexDirection column
         , margin auto
         , maxWidth (px maxSmallDesktop)
-        , margin (rem 0)
-        , padding2 (rem 2) (rem 1)
+        , margin2 (rem 0) auto
+        , padding (rem 1)
         , width auto
         , withMediaTabletPortraitUp
-            [ padding (rem 3)
-            ]
-        , withMediaTabletLandscapeUp
-            [ padding2 (rem 4) (rem 3)
-            ]
-        , withMediaDesktopUp
-            [ margin2 (rem 0) auto
+            [ padding2 (rem 1) (rem 3)
             ]
         ]
 
@@ -365,4 +360,11 @@ pageColumnBlockStyle =
         , lastChild
             [ marginBottom (rem 0)
             ]
+        ]
+
+
+borderWrapper : Style
+borderWrapper =
+    batch
+        [ border3 (rem 0.5) solid teal
         ]

--- a/src/Theme/HeaderTemplate.elm
+++ b/src/Theme/HeaderTemplate.elm
@@ -1,7 +1,7 @@
 module Theme.HeaderTemplate exposing (view)
 
 import Css exposing (Style, absolute, alignItems, backgroundColor, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, baseline, batch, border, border3, borderRadius, bottom, boxShadow, center, color, column, contain, display, displayFlex, em, flexDirection, flexEnd, flexStart, flexWrap, focus, fontFamilies, fontSize, fontWeight, height, inlineBlock, int, justifyContent, left, lineHeight, margin, margin2, margin4, marginBottom, marginLeft, marginRight, marginTop, minWidth, noRepeat, noWrap, none, normal, outline, padding, padding4, pct, position, pseudoElement, px, relative, rem, right, row, solid, spaceBetween, textAlign, top, url, width, zero)
-import Html.Styled exposing (Html, a, button, div, h1, header, img, input, label, node, text)
+import Html.Styled exposing (Html, a, button, div, header, img, input, label, node, text)
 import Html.Styled.Attributes exposing (attribute, css, href, id, placeholder, src, type_)
 import Html.Styled.Events exposing (on, onClick)
 import I18n.Keys exposing (Key(..))
@@ -14,7 +14,7 @@ import Page.Shared.Data
 import Route exposing (Route(..))
 import Shared exposing (Model, Request(..))
 import Theme.FluidScale
-import Theme.Global exposing (centerContent, purple, teal, white, withMediaMobileUp)
+import Theme.Global exposing (borderWrapper, centerContent, purple, teal, white, withMediaMobileUp)
 
 
 view : Model -> Html Msg
@@ -27,7 +27,7 @@ view model =
     header [ css [ headerOuterStyle ] ]
         [ div [ css [ centerContent ] ]
             [ div [ css [ headerContainerStyle ] ]
-                [ viewSiteTitle model.page (t SiteTitle)
+                [ viewSiteTitle (t SiteTitle)
                 , div [ css [ searchButtonsContainerStyle ] ]
                     [ button [ css [ headerBtnStyle ], onClick LanguageChangeRequested ]
                         [ text (t ChangeLanguage) ]
@@ -43,24 +43,20 @@ view model =
         ]
 
 
-viewSiteTitle : Route -> String -> Html Msg
-viewSiteTitle route siteTitle =
-    if route == Index then
-        h1 [ css [ headerBrandStyle ] ] [ text siteTitle ]
-
-    else
-        div [ css [ headerBrandStyle ] ]
-            [ a
-                [ href "/"
-                , css
-                    [ headerLinkStyle
-                    , pseudoElement "after"
-                        [ display none ]
-                    ]
-                ]
-                [ text siteTitle
+viewSiteTitle : String -> Html Msg
+viewSiteTitle siteTitle =
+    div [ css [ headerBrandStyle ] ]
+        [ a
+            [ href "/"
+            , css
+                [ headerLinkStyle
+                , pseudoElement "after"
+                    [ display none ]
                 ]
             ]
+            [ text siteTitle
+            ]
+        ]
 
 
 searchInput : Model -> Html Msg
@@ -120,6 +116,7 @@ headerOuterStyle : Style
 headerOuterStyle =
     batch
         [ backgroundColor teal
+        , borderWrapper
         , color white
         ]
 
@@ -149,7 +146,6 @@ searchButtonsContainerStyle =
         , flexWrap noWrap
         , justifyContent center
         , marginTop (rem 2)
-        , marginBottom (rem 0.3)
         , withMediaMobileUp
             [ margin2 (rem 2) (rem 0)
             , alignItems flexEnd

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -7,7 +7,7 @@ import Html.Styled.Attributes exposing (css)
 import Message exposing (Msg)
 import Shared exposing (Model)
 import Theme.FooterTemplate as FooterTemplate
-import Theme.Global exposing (globalStyles, lightTeal, teal)
+import Theme.Global exposing (borderWrapper, globalStyles, lightTeal, teal)
 import Theme.HeaderTemplate as HeaderTemplate
 
 
@@ -38,6 +38,6 @@ pageWrapperStyles =
 mainContainerStyles : Style
 mainContainerStyles =
     batch
-        [ border3 (rem 0.5) solid teal
+        [ borderWrapper
         , backgroundColor lightTeal
         ]


### PR DESCRIPTION
Fixes #220

## Description

- Updates homepage title (but uses nextdoor nature hub instead of library)
- Removes h1 from logo on homepage as now exists as title instead
- Adjusts spacing around titles and adds border to header to better match spacing in wireframes