### PR TITLE
WIP featured guides

### DIFF
--- a/content/guides/en/test-guide-with-all-content.md
+++ b/content/guides/en/test-guide-with-all-content.md
@@ -13,6 +13,7 @@ relatedGuides:
   - "Finding Funding "
 relatedStories:
   - Test story with minimal fields
+featured: True
 ---
 
 \#﻿# Test guide with lots of info

--- a/src/Page/Guide/Data.elm
+++ b/src/Page/Guide/Data.elm
@@ -19,6 +19,7 @@ type alias Guide =
     , slug : String
     , fullTextMarkdown : String
     , summary : String
+    , maybeFeatured : Maybe String
     , maybeImage : Maybe Image
     , maybeVideo : Maybe Page.Shared.Data.VideoMeta
     , maybeAudio : Maybe Page.Shared.Data.AudioMeta
@@ -61,6 +62,7 @@ blankGuide language =
     , slug = t Guide404Slug
     , fullTextMarkdown = t Guide404Body
     , summary = t Guide404Title
+    , maybeFeatured = Nothing
     , maybeImage = Nothing
     , maybeVideo = Nothing
     , maybeAudio = Nothing
@@ -81,6 +83,8 @@ guideDictDecoder =
                 (Json.Decode.field "content" Json.Decode.string |> Json.Decode.Extra.withDefault "")
             |> Json.Decode.Extra.andMap
                 (Json.Decode.field "summary" Json.Decode.string |> Json.Decode.Extra.withDefault "")
+            |> Json.Decode.Extra.andMap
+                (Json.Decode.maybe (Json.Decode.field "featured" Json.Decode.string))
             |> Json.Decode.Extra.andMap
                 (Json.Decode.maybe (Json.Decode.field "image" imageDecoder))
             |> Json.Decode.Extra.andMap

--- a/src/Page/Guides/Data.elm
+++ b/src/Page/Guides/Data.elm
@@ -1,4 +1,4 @@
-module Page.Guides.Data exposing (actionTeaserDecoder, actionTeaserListDecoder, guideTeaserDecoder, guideTeaserListEncoder, guideTeaserListString, internalGuideTeaserDecoder, internalGuideTeaserListDecoder, teaserListFromGuideDict)
+module Page.Guides.Data exposing (actionTeaserDecoder, actionTeaserListDecoder, guideTeaserDecoder, guideTeaserListEncoder, guideTeaserListString, internalGuideTeaserDecoder, internalGuideTeaserListDecoder, teaserListFromGuideDict, featuredGuides)
 
 import Dict
 import I18n.Translate exposing (Language)
@@ -44,6 +44,13 @@ guideTeaserListString guideTeaserList =
 guideTeaserListEncoder : List Page.Shared.Data.GuideTeaser -> Encode.Value
 guideTeaserListEncoder guideTeasers =
     Encode.list guideTeaserEncoder guideTeasers
+
+
+featuredGuides : Page.Guide.Data.Guides -> Dict.Dict String Page.Guide.Data.Guide
+featuredGuides guides =
+    Dict.filter
+        (\(_, guide) -> Maybe.withDefault "" guide.maybeFeatured == "True")
+        guides.en
 
 
 teaserListFromGuideDict :

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -6,10 +6,14 @@ import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (translate)
 import Message exposing (Msg)
 import Page.Guides.Data
+import Page.Guide.Data
 import Page.Guides.View
+import Page.Guides.Data
 import Shared exposing (Model)
 import Theme.Global exposing (centerContent, contentWrapper, pageColumnBlockStyle, pageColumnStyle, topTwoColumnsWrapperStyle)
-
+import List
+import Dict
+import Maybe
 
 view : Model -> Html Msg
 view model =
@@ -17,6 +21,7 @@ view model =
         t : Key -> String
         t =
             translate model.language
+                    
     in
     div [ css [ centerContent ] ]
         [ h1 []
@@ -26,7 +31,8 @@ view model =
                 [ div [ css [ pageColumnStyle ] ]
                     (viewTextColumn t [ WelcomeP1, WelcomeP2, WelcomeP3 ])
                 , div [ css [ pageColumnStyle ] ]
-                    [ List.take 4 (Page.Guides.Data.teaserListFromGuideDict model.language model.content.guides)
+                    [ Page.Guides.Data.featuredGuides model.content.guides  -- List.take 4 (Page.Guides.Data.teaserListFromGuideDict model.language model.content.guides)
+                        |> Page.Guides.Data.teaserListFromGuideDict
                         |> Page.Guides.View.viewGuideTeaserList False
                     ]
                 ]


### PR DESCRIPTION
Fixes #256 

(VERY BROKEN)

## Featured Guides

- guide content can have a "featured: True" value
- is parsed in to model

TODO:
- filter out guides that are "featured"
- render "Featured Guides" component on index

@geeksforsocialchange/developers
