### PR TITLE
Correct public image path for uploads

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -4,6 +4,7 @@ backend:
   branch: main # Branch to update
 publish_mode: editorial_workflow
 media_folder: public/images/uploads
+public_folder: /images/uploads
 i18n:
   structure: multiple_folders
   locales: [en, cy]


### PR DESCRIPTION
Fixes #301

## Description

- Add `public_folder` path for location of uploaded images

As per: https://decapcms.org/docs/configuration-options/#media-and-public-folders

@geeksforsocialchange/developers
