### PR TITLE
improve search

### DIFF
--- a/src/I18n/Cy.elm
+++ b/src/I18n/Cy.elm
@@ -12,6 +12,9 @@ cyStrings key =
         GuidesTitle ->
             "[cCc] Guides CY"
 
+        GuidesTitleFiltered num query ->
+            num ++ " CY guides on '" ++ query ++ "' [cCc]"
+
         ChangeLanguage ->
             "[cCc] Switch to English"
 

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -145,6 +145,9 @@ enStrings key =
         GuidesTitle ->
             "[cCc] Guides"
 
+        GuidesTitleFiltered num query ->
+            num ++ " guides on '" ++ query ++ "' [cCc]"
+
         SearchPlaceholder ->
             "Search the hub"
 

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -46,5 +46,6 @@ type Key
     | RelatedStoriesHeading
       --- Guides Page
     | GuidesTitle
+    | GuidesTitleFiltered String String
     | SearchPlaceholder
     | ExploreGuidesListPlaceholder

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -144,7 +144,11 @@ update msg model =
         GotActions result ->
             case result of
                 Ok list ->
-                    ( { model | externalActions = Success list }, Cmd.none )
+                    let
+                        actions =
+                            List.sortBy .title list
+                    in
+                    ( { model | externalActions = Success actions }, Cmd.none )
 
                 Err _ ->
                     ( { model | externalActions = Failure }, Cmd.none )

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -71,6 +71,7 @@ init flags url key =
       , content = Shared.contentDictDecoder flags
       , language = English
       , search = []
+      , query = ""
       , externalActions = Loading
       }
     , getActions
@@ -170,8 +171,8 @@ update msg model =
                 Cmd.none
             )
 
-        SearchChanged searchResult ->
-            ( { model | search = searchResult }, Cmd.none )
+        SearchChanged searchResult query ->
+            ( { model | search = searchResult, query = query }, Cmd.none )
 
 
 openCookieBanner : CookieState -> CookieState

--- a/src/Message.elm
+++ b/src/Message.elm
@@ -13,5 +13,6 @@ type Msg
     | CookieSettingsButtonClicked
     | CookiesAccepted
     | CookiesDeclined
-    | SearchChanged (List Page.Shared.Data.GuideTeaser)
+    | SearchChanged (List Page.Shared.Data.GuideTeaser) String
+      -- | SearchChanged (List Page.Shared.Data.GuideTeaser)
     | GotActions (Result Http.Error (List Page.Shared.Data.GuideTeaser))

--- a/src/Message.elm
+++ b/src/Message.elm
@@ -14,5 +14,4 @@ type Msg
     | CookiesAccepted
     | CookiesDeclined
     | SearchChanged (List Page.Shared.Data.GuideTeaser) String
-      -- | SearchChanged (List Page.Shared.Data.GuideTeaser)
     | GotActions (Result Http.Error (List Page.Shared.Data.GuideTeaser))

--- a/src/Page/Guides/Data.elm
+++ b/src/Page/Guides/Data.elm
@@ -60,6 +60,7 @@ teaserListFromGuideDict language guides =
                 , maybeImage = guideImagefromTeaserImage g.maybeImage
                 }
             )
+        |> List.sortBy .title
 
 
 guideImagefromTeaserImage : Maybe Page.Guide.Data.Image -> Maybe Page.Shared.Data.GuideTeaserImage

--- a/src/Page/Guides/View.elm
+++ b/src/Page/Guides/View.elm
@@ -21,7 +21,7 @@ view model =
 
         teaserList : List Page.Shared.Data.GuideTeaser
         teaserList =
-            if List.length model.search > 0 then
+            if String.length model.query > 0 then
                 model.search
 
             else if model.language == Welsh then

--- a/src/Page/Guides/View.elm
+++ b/src/Page/Guides/View.elm
@@ -40,7 +40,13 @@ view model =
     in
     div [ css [ centerContent ] ]
         [ h1 []
-            [ text (t GuidesTitle) ]
+            [ text <|
+                if String.length model.query > 0 then
+                    t <| GuidesTitleFiltered (String.fromInt <| List.length model.search) model.query
+
+                else
+                    t GuidesTitle
+            ]
         , div
             [ css [ contentWrapper ] ]
             [ viewGuideTeaserList True teaserList

--- a/src/Page/Guides/View.elm
+++ b/src/Page/Guides/View.elm
@@ -39,7 +39,7 @@ view model =
                         List.concat [ Page.Guides.Data.teaserListFromGuideDict model.language model.content.guides, list ]
     in
     div [ css [ centerContent ] ]
-        [ h1 [ attribute "aria-live" "polite" ]
+        [ h1 [ attribute "aria-live" "alert" ]
             [ text <|
                 if String.length model.query > 0 then
                     t <| GuidesTitleFiltered (String.fromInt <| List.length model.search) model.query

--- a/src/Page/Guides/View.elm
+++ b/src/Page/Guides/View.elm
@@ -102,7 +102,6 @@ viewGuideTeaserList includeSummary teasers =
     if List.length teasers > 0 then
         ul [ css [ Theme.Global.teasersContainerStyle ] ]
             (teasers
-                |> List.sortBy .title
                 |> List.map
                     (\teaser -> viewGuideTeaser includeSummary teaser)
             )

--- a/src/Page/Guides/View.elm
+++ b/src/Page/Guides/View.elm
@@ -1,7 +1,7 @@
 module Page.Guides.View exposing (view, viewGuideTeaserList)
 
 import Html.Styled exposing (Html, a, div, h1, img, li, p, text, ul)
-import Html.Styled.Attributes exposing (alt, css, href, src)
+import Html.Styled.Attributes exposing (alt, attribute, css, href, src)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..), translate)
 import List
@@ -39,7 +39,7 @@ view model =
                         List.concat [ Page.Guides.Data.teaserListFromGuideDict model.language model.content.guides, list ]
     in
     div [ css [ centerContent ] ]
-        [ h1 []
+        [ h1 [ attribute "aria-live" "polite" ]
             [ text <|
                 if String.length model.query > 0 then
                     t <| GuidesTitleFiltered (String.fromInt <| List.length model.search) model.query

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -18,6 +18,7 @@ type alias Model =
     , language : Language
     , content : Content
     , search : List Page.Shared.Data.GuideTeaser
+    , query : String
     , externalActions : Request
     }
 

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,10 +1,26 @@
-module Theme.Global exposing (borderWrapper, centerContent, contentWrapper, featureImageStyle, globalStyles, lightTeal, listStyleNone, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
+module Theme.Global exposing (borderWrapper, centerContent, contentWrapper, featureImageStyle, globalStyles, lightTeal, listStyleNone, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, screenReaderOnly, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
 
-import Css exposing (Color, Style, alignItems, auto, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, border3, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contain, contentBox, cover, cursor, display, displayFlex, em, ex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, inlineBlock, int, justifyContent, lastChild, listStyle, margin, margin2, margin3, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, paddingLeft, pct, pointer, property, pseudoElement, px, rem, row, solid, spaceBetween, textDecoration, url, width, wrap, zero)
+import Css exposing (Color, Style, absolute, alignItems, auto, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, border3, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contain, contentBox, cover, cursor, display, displayFlex, em, ex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, inlineBlock, int, justifyContent, lastChild, left, listStyle, margin, margin2, margin3, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, paddingLeft, pct, pointer, position, property, pseudoElement, px, rem, row, solid, spaceBetween, textDecoration, top, url, width, wrap, zero)
 import Css.Global exposing (global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html)
 import Theme.FluidScale
+
+
+
+-- Accessibility helpers
+
+
+screenReaderOnly : Style
+screenReaderOnly =
+    batch
+        [ position absolute
+        , left (px -10000)
+        , top auto
+        , width (px 1)
+        , height (px 1)
+        , overflow hidden
+        ]
 
 
 

--- a/src/Theme/HeaderTemplate.elm
+++ b/src/Theme/HeaderTemplate.elm
@@ -1,8 +1,8 @@
 module Theme.HeaderTemplate exposing (view)
 
-import Css exposing (Style, absolute, alignItems, backgroundColor, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, baseline, batch, border, border3, borderRadius, bottom, boxShadow, center, color, column, contain, display, displayFlex, em, flexDirection, flexEnd, flexStart, flexWrap, focus, fontFamilies, fontSize, fontWeight, height, inlineBlock, int, justifyContent, left, lineHeight, margin, margin2, margin4, marginBottom, marginLeft, marginRight, marginTop, minWidth, noRepeat, noWrap, none, normal, outline, padding, padding4, pct, position, pseudoElement, px, relative, rem, right, row, solid, spaceBetween, textAlign, top, url, width, zero)
+import Css exposing (Style, absolute, alignItems, backgroundColor, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, baseline, batch, border, border3, borderRadius, bottom, boxShadow, center, color, column, contain, display, displayFlex, em, flexDirection, flexEnd, flexStart, flexWrap, focus, fontFamilies, fontSize, fontWeight, height, inlineBlock, int, justifyContent, left, lineHeight, margin, margin2, marginBottom, marginLeft, marginRight, marginTop, minWidth, noRepeat, noWrap, none, normal, outline, padding, padding4, pct, position, pseudoElement, px, rem, right, row, solid, spaceBetween, textAlign, top, url, width, zero)
 import Html.Styled exposing (Html, a, button, div, header, img, input, label, node, text)
-import Html.Styled.Attributes exposing (attribute, css, href, id, placeholder, src, type_)
+import Html.Styled.Attributes exposing (attribute, css, for, href, id, placeholder, src, type_)
 import Html.Styled.Events exposing (on, onClick)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..), translate)
@@ -14,7 +14,7 @@ import Page.Shared.Data
 import Route exposing (Route(..))
 import Shared exposing (Model, Request(..))
 import Theme.FluidScale
-import Theme.Global exposing (borderWrapper, centerContent, purple, teal, white, withMediaMobileUp)
+import Theme.Global exposing (borderWrapper, centerContent, purple, screenReaderOnly, teal, white, withMediaMobileUp)
 
 
 view : Model -> Html Msg
@@ -82,8 +82,9 @@ searchInput model =
                     Success list ->
                         List.concat [ Page.Guides.Data.teaserListFromGuideDict model.language model.content.guides, list ]
     in
-    label [ css [ searchStyle ] ]
-        [ text (t SearchPlaceholder)
+    div []
+        [ label [ for "search", css [ screenReaderOnly ] ]
+            [ text (t SearchPlaceholder) ]
         , node "search-input"
             [ Html.Styled.Attributes.property "searchResult" <| Page.Guides.Data.guideTeaserListEncoder model.search
             , attribute "search-input" <| Page.Guides.Data.guideTeaserListString teaserList
@@ -200,16 +201,6 @@ headerBtnStyle =
         , withMediaMobileUp
             [ textAlign right
             ]
-        ]
-
-
-searchStyle : Style
-searchStyle =
-    batch
-        [ color white
-        , margin4 (rem 0.5) (rem 0) (rem 0.5) (rem 0.5)
-        , height (rem 2)
-        , position relative
         ]
 
 

--- a/src/Theme/HeaderTemplate.elm
+++ b/src/Theme/HeaderTemplate.elm
@@ -88,9 +88,7 @@ searchInput model =
             [ Html.Styled.Attributes.property "searchResult" <| Page.Guides.Data.guideTeaserListEncoder model.search
             , attribute "search-input" <| Page.Guides.Data.guideTeaserListString teaserList
             , on "resultChanged" <|
-                Json.Decode.map Message.SearchChanged <|
-                    Json.Decode.at [ "target", "searchResult" ] <|
-                        Json.Decode.list Page.Guides.Data.internalGuideTeaserDecoder
+                Json.Decode.map2 Message.SearchChanged (Json.Decode.at [ "target", "searchResult" ] (Json.Decode.list Page.Guides.Data.internalGuideTeaserDecoder)) (Json.Decode.at [ "target", "_input", "value" ] Json.Decode.string)
             ]
             [ input [ id "search", type_ "text", placeholder (t SearchPlaceholder), css [ searchInputStyle ] ] [] ]
         , img [ src "/images/arrow-right-purple.svg", css [ arrowStyle ] ] []

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -2,6 +2,8 @@ import Fuse from "fuse.js";
 
 const searchOpts = {
   keys: ["title", "summary"],
+  ignoreLocation: true,
+  threshold: 0.4,
 };
 
 const template = document.createElement("template");


### PR DESCRIPTION
Fixes #8 

## Description

- much stricter scoping of search
- if search is active and no results are found no guides are shown
- number of guide matching found and search term shown in header
- above info exposed to screen readers via `aria-live` attribute
- ordering of teasers is done outside the view function so that they are alphabetical when no filtering is applied or sorted by relevance on a search.

@geeksforsocialchange/developers
