### PR TITLE
Jump to top of page on navigation

### DIFF
--- a/src/Message.elm
+++ b/src/Message.elm
@@ -15,3 +15,4 @@ type Msg
     | CookiesDeclined
     | SearchChanged (List Page.Shared.Data.GuideTeaser)
     | GotActions (Result Http.Error (List Page.Shared.Data.GuideTeaser))
+    | NoOp

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -1,7 +1,7 @@
 module Page.Guide.View exposing (view)
 
 import Css exposing (Style, batch, center, column, displayFlex, flexDirection, flexWrap, fontFamilies, justifyContent, listStyle, marginTop, maxWidth, none, padding2, paddingLeft, px, wrap, zero)
-import Html.Styled exposing (Html, a, div, h1, h2, img, li, text, ul)
+import Html.Styled exposing (Html, a, div, h2, img, li, text, ul)
 import Html.Styled.Attributes exposing (alt, css, href, src)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..), translate)
@@ -13,14 +13,14 @@ import Page.Shared.View
 import Page.Story.Data
 import Route exposing (Route(..))
 import Theme.FluidScale exposing (fontSize1)
-import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, pageColumnBlockStyle, pageColumnStyle, roundedCornerStyle, teaserImageStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, pageColumnBlockStyle, pageColumnStyle, primaryHeader, roundedCornerStyle, teaserImageStyle, topTwoColumnsWrapperStyle)
 import Theme.Markdown exposing (markdownToHtml)
 
 
 view : Language -> Page.Guide.Data.Guide -> List Page.Guide.Data.GuideListItem -> List Page.Story.Data.StoryTeaser -> Html Msg
 view language guide allGuides allStories =
     div [ css [ centerContent ] ]
-        [ h1 [ css [ guideTitleStyle ] ] [ text guide.title ]
+        [ primaryHeader guide.title
         , viewSummaryImageRow guide
         , viewRow
             ( markdownToHtml guide.fullTextMarkdown
@@ -237,11 +237,6 @@ storyteaserContainerStyle =
         , flexDirection column
         , maxWidth (px 150)
         ]
-
-
-guideTitleStyle : Style
-guideTitleStyle =
-    fontFamilies [ "Ludicrous", "serif" ]
 
 
 guideSummaryStyle : Style

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -20,7 +20,7 @@ import Theme.Markdown exposing (markdownToHtml)
 view : Language -> Page.Guide.Data.Guide -> List Page.Guide.Data.GuideListItem -> List Page.Story.Data.StoryTeaser -> Html Msg
 view language guide allGuides allStories =
     div [ css [ centerContent ] ]
-        [ primaryHeader guide.title
+        [ primaryHeader [] guide.title
         , viewSummaryImageRow guide
         , viewRow
             ( markdownToHtml guide.fullTextMarkdown

--- a/src/Page/Guides/View.elm
+++ b/src/Page/Guides/View.elm
@@ -47,7 +47,7 @@ view model =
                 t GuidesTitle
     in
     div [ css [ centerContent ] ]
-        [ primaryHeader headerText
+        [ primaryHeader [ attribute "aria-live" "alert" ] headerText
         , div
             [ css [ contentWrapper ] ]
             [ viewGuideTeaserList True teaserList

--- a/src/Page/Guides/View.elm
+++ b/src/Page/Guides/View.elm
@@ -37,9 +37,17 @@ view model =
 
                     Success list ->
                         List.concat [ Page.Guides.Data.teaserListFromGuideDict model.language model.content.guides, list ]
+
+        headerText : String
+        headerText =
+            if String.length model.query > 0 then
+                t <| GuidesTitleFiltered (String.fromInt <| List.length model.search) model.query
+
+            else
+                t GuidesTitle
     in
     div [ css [ centerContent ] ]
-        [ primaryHeader (t GuidesTitle)
+        [ primaryHeader headerText
         , div
             [ css [ contentWrapper ] ]
             [ viewGuideTeaserList True teaserList

--- a/src/Page/Guides/View.elm
+++ b/src/Page/Guides/View.elm
@@ -1,6 +1,6 @@
 module Page.Guides.View exposing (view, viewGuideTeaserList)
 
-import Html.Styled exposing (Html, a, div, h1, img, li, p, text, ul)
+import Html.Styled exposing (Html, a, div, img, li, p, text, ul)
 import Html.Styled.Attributes exposing (alt, css, href, src)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..), translate)
@@ -9,7 +9,7 @@ import Message exposing (Msg)
 import Page.Guides.Data
 import Page.Shared.Data
 import Shared exposing (Model, Request(..))
-import Theme.Global exposing (centerContent, contentWrapper)
+import Theme.Global exposing (centerContent, contentWrapper, primaryHeader)
 
 
 view : Model -> Html Msg
@@ -39,8 +39,7 @@ view model =
                         List.concat [ Page.Guides.Data.teaserListFromGuideDict model.language model.content.guides, list ]
     in
     div [ css [ centerContent ] ]
-        [ h1 []
-            [ text (t GuidesTitle) ]
+        [ primaryHeader (t GuidesTitle)
         , div
             [ css [ contentWrapper ] ]
             [ viewGuideTeaserList True teaserList

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -1,6 +1,6 @@
 module Page.Index exposing (view)
 
-import Html.Styled exposing (Html, div, h1, p, text)
+import Html.Styled exposing (Html, div, p, text)
 import Html.Styled.Attributes exposing (css)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (translate)
@@ -8,7 +8,7 @@ import Message exposing (Msg)
 import Page.Guides.Data
 import Page.Guides.View
 import Shared exposing (Model)
-import Theme.Global exposing (centerContent, contentWrapper, pageColumnBlockStyle, pageColumnStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (centerContent, contentWrapper, pageColumnBlockStyle, pageColumnStyle, primaryHeader, topTwoColumnsWrapperStyle)
 
 
 view : Model -> Html Msg
@@ -19,8 +19,7 @@ view model =
             translate model.language
     in
     div [ css [ centerContent ] ]
-        [ h1 []
-            [ text (t HomeTitle) ]
+        [ primaryHeader (t HomeTitle)
         , div [ css [ contentWrapper ] ]
             [ div [ css [ topTwoColumnsWrapperStyle ] ]
                 [ div [ css [ pageColumnStyle ] ]

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -19,7 +19,7 @@ view model =
             translate model.language
     in
     div [ css [ centerContent ] ]
-        [ primaryHeader (t HomeTitle)
+        [ primaryHeader [] (t HomeTitle)
         , div [ css [ contentWrapper ] ]
             [ div [ css [ topTwoColumnsWrapperStyle ] ]
                 [ div [ css [ pageColumnStyle ] ]

--- a/src/Page/Story/View.elm
+++ b/src/Page/Story/View.elm
@@ -8,7 +8,7 @@ import I18n.Translate exposing (Language(..), translate)
 import Message exposing (Msg)
 import Page.Guides.View
 import Page.Story.Data
-import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, pageColumnStyle, roundedCornerStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, pageColumnStyle, primaryHeader, roundedCornerStyle, topTwoColumnsWrapperStyle)
 import Theme.Markdown exposing (markdownToHtml)
 
 

--- a/src/Page/Story/View.elm
+++ b/src/Page/Story/View.elm
@@ -36,7 +36,10 @@ view language story =
                                 text ""
                         , case story.maybeLocation of
                             Just location ->
-                                p [] [ text location ]
+                                div []
+                                    [ h3 [] [ text (t WhereSubHeading) ]
+                                    , p [] [ text location ]
+                                    ]
 
                             Nothing ->
                                 text ""

--- a/src/Page/Story/View.elm
+++ b/src/Page/Story/View.elm
@@ -20,7 +20,7 @@ view language story =
             translate language
     in
     div [ css [ centerContent ] ]
-        [ primaryHeader story.title
+        [ primaryHeader [] story.title
         , div [ css [ contentWrapper, width (pct 100) ] ]
             [ div [ css [ topTwoColumnsWrapperStyle ] ]
                 [ div [ css [ pageColumnStyle ] ]

--- a/src/Page/Story/View.elm
+++ b/src/Page/Story/View.elm
@@ -1,19 +1,19 @@
 module Page.Story.View exposing (view)
 
 import Css exposing (Style, batch, margin3, rem)
-import Html.Styled exposing (Html, div, h1, img, p, text)
+import Html.Styled exposing (Html, div, img, p, text)
 import Html.Styled.Attributes exposing (alt, css, src)
 import Message exposing (Msg)
 import Page.Guides.View
 import Page.Story.Data
-import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, pageColumnStyle, roundedCornerStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, pageColumnStyle, primaryHeader, roundedCornerStyle, topTwoColumnsWrapperStyle)
 import Theme.Markdown exposing (markdownToHtml)
 
 
 view : Page.Story.Data.Story -> Html Msg
 view story =
     div [ css [ centerContent ] ]
-        [ h1 [] [ text story.title ]
+        [ primaryHeader story.title
         , div [ css [ contentWrapper ] ]
             [ div [ css [ topTwoColumnsWrapperStyle ] ]
                 [ div [ css [ pageColumnStyle ] ]

--- a/src/Page/View.elm
+++ b/src/Page/View.elm
@@ -1,16 +1,16 @@
 module Page.View exposing (view)
 
-import Html.Styled exposing (Html, div, h1, text)
+import Html.Styled exposing (Html, div)
 import Html.Styled.Attributes exposing (css)
 import Message exposing (Msg)
 import Page.Data
-import Theme.Global exposing (centerContent)
+import Theme.Global exposing (centerContent, primaryHeader)
 import Theme.Markdown exposing (markdownToHtml)
 
 
 view : Page.Data.Page -> Html Msg
 view page =
     div [ css [ centerContent ] ]
-        [ h1 [] [ text page.title ]
+        [ primaryHeader page.title
         , div [] (markdownToHtml page.fullTextMarkdown)
         ]

--- a/src/Page/View.elm
+++ b/src/Page/View.elm
@@ -11,6 +11,6 @@ import Theme.Markdown exposing (markdownToHtml)
 view : Page.Data.Page -> Html Msg
 view page =
     div [ css [ centerContent ] ]
-        [ primaryHeader page.title
+        [ primaryHeader [] page.title
         , div [] (markdownToHtml page.fullTextMarkdown)
         ]

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,9 +1,10 @@
-module Theme.Global exposing (borderWrapper, centerContent, contentWrapper, featureImageStyle, globalStyles, lightTeal, listStyleNone, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, screenReaderOnly, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
+module Theme.Global exposing (borderWrapper, centerContent, contentWrapper, featureImageStyle, globalStyles, lightTeal, listStyleNone, pageColumnBlockStyle, pageColumnStyle, primaryHeader, purple, roundedCornerStyle, screenReaderOnly, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
 
 import Css exposing (Color, Style, absolute, alignItems, auto, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, border3, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contain, contentBox, cover, cursor, display, displayFlex, em, ex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, inlineBlock, int, justifyContent, lastChild, left, listStyle, margin, margin2, margin3, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, paddingLeft, pct, pointer, position, property, pseudoElement, px, rem, row, solid, spaceBetween, textDecoration, top, url, width, wrap, zero)
 import Css.Global exposing (global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
-import Html.Styled exposing (Html)
+import Html.Styled exposing (Html, h1, text)
+import Html.Styled.Attributes exposing (css, id)
 import Theme.FluidScale
 
 
@@ -199,7 +200,7 @@ globalStyles =
 -- Helpers
 
 
-primaryHeader : String -> Html Msg
+primaryHeader : String -> Html msg
 primaryHeader title =
     h1 [ css [ primaryHeaderStyle ], id "focus-target" ] [ text title ]
 

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,9 +1,11 @@
-module Theme.Global exposing (borderWrapper, centerContent, contentWrapper, featureImageStyle, globalStyles, lightTeal, listStyleNone, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
+module Theme.Global exposing (borderWrapper, centerContent, contentWrapper, featureImageStyle, globalStyles, lightTeal, listStyleNone, pageColumnBlockStyle, pageColumnStyle, primaryHeader, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
 
 import Css exposing (Color, Style, alignItems, auto, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, border3, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contain, contentBox, cover, cursor, display, displayFlex, em, ex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, inlineBlock, int, justifyContent, lastChild, listStyle, margin, margin2, margin3, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, paddingLeft, pct, pointer, property, pseudoElement, px, rem, row, solid, spaceBetween, textDecoration, url, width, wrap, zero)
 import Css.Global exposing (global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
-import Html.Styled exposing (Html)
+import Html.Styled exposing (Html, h1, text)
+import Html.Styled.Attributes exposing (css, id)
+import Message exposing (Msg)
 import Theme.FluidScale
 
 
@@ -176,6 +178,16 @@ globalStyles =
 
 
 -- Helpers
+
+
+primaryHeader : String -> Html Msg
+primaryHeader title =
+    h1 [ css [ primaryHeaderStyle ], id "focus-target" ] [ text title ]
+
+
+primaryHeaderStyle : Style
+primaryHeaderStyle =
+    fontFamilies [ "Ludicrous", "serif" ]
 
 
 listStyleNone : Style

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -4,7 +4,7 @@ import Css exposing (Color, Style, absolute, alignItems, auto, backgroundImage, 
 import Css.Global exposing (global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html, h1, text)
-import Html.Styled.Attributes exposing (css, id)
+import Html.Styled.Attributes exposing (id, tabindex)
 import Theme.FluidScale
 
 
@@ -202,12 +202,7 @@ globalStyles =
 
 primaryHeader : String -> Html msg
 primaryHeader title =
-    h1 [ css [ primaryHeaderStyle ], id "focus-target" ] [ text title ]
-
-
-primaryHeaderStyle : Style
-primaryHeaderStyle =
-    fontFamilies [ "Ludicrous", "serif" ]
+    h1 [ id "focus-target", tabindex -1 ] [ text title ]
 
 
 listStyleNone : Style

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -200,9 +200,9 @@ globalStyles =
 -- Helpers
 
 
-primaryHeader : String -> Html msg
-primaryHeader title =
-    h1 [ id "focus-target", tabindex -1 ] [ text title ]
+primaryHeader : List (Html.Styled.Attribute msg) -> String -> Html msg
+primaryHeader extraAttributes title =
+    h1 ([ id "focus-target", tabindex -1 ] ++ extraAttributes) [ text title ]
 
 
 listStyleNone : Style

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -14,7 +14,6 @@ import Theme.HeaderTemplate as HeaderTemplate
 view : Model -> Html Msg -> Html Msg
 view model content =
     div []
-        -- id "focus-target" ]
         [ globalStyles
         , div
             [ css [ pageWrapperStyles ] ]

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -3,7 +3,7 @@ module Theme.PageTemplate exposing (view)
 import CookieBanner
 import Css exposing (Style, backgroundColor, batch, border3, hidden, overflowX, pct, rem, solid, width)
 import Html.Styled exposing (Html, div, main_)
-import Html.Styled.Attributes exposing (css)
+import Html.Styled.Attributes exposing (css, id)
 import Message exposing (Msg)
 import Shared exposing (Model)
 import Theme.FooterTemplate as FooterTemplate
@@ -14,6 +14,7 @@ import Theme.HeaderTemplate as HeaderTemplate
 view : Model -> Html Msg -> Html Msg
 view model content =
     div []
+        -- id "focus-target" ]
         [ globalStyles
         , div
             [ css [ pageWrapperStyles ] ]

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -3,7 +3,7 @@ module Theme.PageTemplate exposing (view)
 import CookieBanner
 import Css exposing (Style, backgroundColor, batch, border3, hidden, overflowX, pct, rem, solid, width)
 import Html.Styled exposing (Html, div, main_)
-import Html.Styled.Attributes exposing (css, id)
+import Html.Styled.Attributes exposing (css)
 import Message exposing (Msg)
 import Shared exposing (Model)
 import Theme.FooterTemplate as FooterTemplate


### PR DESCRIPTION
Fixes #162 

## Description

When clicking a link the browser window is reset to the top of the new page.

Also all the primary headers are rendered through one point so styling is consistent across all pages.


@geeksforsocialchange/developers
