### PR TITLE
fix broken images in search results

### DIFF
--- a/src/Page/Guides/Data.elm
+++ b/src/Page/Guides/Data.elm
@@ -28,7 +28,7 @@ guideTeaserEncoder guideTeaser =
         , ( "maybeImage"
           , case guideTeaser.maybeImage of
                 Just image ->
-                    Encode.object [ ( "url", Encode.string image.src ), ( "alt", Encode.string image.alt ) ]
+                    Encode.object [ ( "src", Encode.string image.src ), ( "alt", Encode.string image.alt ) ]
 
                 Nothing ->
                     Encode.null


### PR DESCRIPTION
Fixes #312 

## Description

- just a mismatch between keys in the json and elm record


@geeksforsocialchange/developers
