### PR TITLE
Randomly assign stories and guides as teasers on the homepage

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,6 +11,7 @@
             "elm/core": "1.0.5",
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
+            "elm/random": "1.0.0",
             "elm/url": "1.0.0",
             "elm-community/json-extra": "4.3.0",
             "rtfeldman/elm-css": "18.0.0"
@@ -33,8 +34,6 @@
             "elm/html": "1.0.0",
             "elm-explorations/test": "2.1.1"
         },
-        "indirect": {
-            "elm/random": "1.0.0"
-        }
+        "indirect": {}
     }
 }

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -130,6 +130,12 @@ enStrings key =
         WelcomeP3 ->
             "[cCc] The goal of Nextdoor Nature is to get at least 1 in 4 people across the UK taking Action for Nature. This hub aims to support anyone who is interested in finding out what they can do, and how they can get other people involved."
 
+        GuideHighlightsSubtitle ->
+            "Guide highlights"
+
+        StoryHighlightsSubtitle ->
+            "Story highlights"
+
         ---
         -- Guide Page
         ---

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -41,6 +41,8 @@ type Key
     | WelcomeP1
     | WelcomeP2
     | WelcomeP3
+    | GuideHighlightsSubtitle
+    | StoryHighlightsSubtitle
       --- Guide Page
     | RelatedGuidesHeading
     | RelatedStoriesHeading

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -19,6 +19,7 @@ import Page.Index
 import Page.Story.Data
 import Page.Story.View
 import Page.View
+import Random
 import Route exposing (Route(..))
 import Shared exposing (CookieState, Model, Request(..))
 import Theme.PageTemplate
@@ -73,8 +74,12 @@ init flags url key =
       , search = []
       , query = ""
       , externalActions = Loading
+      , seed = Nothing
       }
-    , getActions
+    , Cmd.batch
+        [ getActions
+        , Random.generate UpdateSeed Random.independentSeed
+        ]
     )
 
 
@@ -177,6 +182,9 @@ update msg model =
 
         SearchChanged searchResult query ->
             ( { model | search = searchResult, query = query }, Cmd.none )
+
+        UpdateSeed seed ->
+            ( { model | seed = Just seed }, Cmd.none )
 
 
 openCookieBanner : CookieState -> CookieState

--- a/src/Message.elm
+++ b/src/Message.elm
@@ -13,5 +13,5 @@ type Msg
     | CookieSettingsButtonClicked
     | CookiesAccepted
     | CookiesDeclined
-    | SearchChanged (List Page.Shared.Data.GuideTeaser) String
-    | GotActions (Result Http.Error (List Page.Shared.Data.GuideTeaser))
+    | SearchChanged (List Page.Shared.Data.Teaser) String
+    | GotActions (Result Http.Error (List Page.Shared.Data.Teaser))

--- a/src/Message.elm
+++ b/src/Message.elm
@@ -14,6 +14,7 @@ type Msg
     | CookieSettingsButtonClicked
     | CookiesAccepted
     | CookiesDeclined
-    | SearchChanged (List Page.Shared.Data.GuideTeaser) String
-    | GotActions (Result Http.Error (List Page.Shared.Data.GuideTeaser))
+    | SearchChanged (List Page.Shared.Data.Teaser) String
+    | GotActions (Result Http.Error (List Page.Shared.Data.Teaser))
     | UpdateSeed Random.Seed
+    | NoOp

--- a/src/Message.elm
+++ b/src/Message.elm
@@ -3,6 +3,7 @@ module Message exposing (Msg(..))
 import Browser
 import Http
 import Page.Shared.Data
+import Random
 import Url
 
 
@@ -15,3 +16,4 @@ type Msg
     | CookiesDeclined
     | SearchChanged (List Page.Shared.Data.Teaser) String
     | GotActions (Result Http.Error (List Page.Shared.Data.Teaser))
+    | UpdateSeed Random.Seed

--- a/src/Page/Guides/Data.elm
+++ b/src/Page/Guides/Data.elm
@@ -52,9 +52,9 @@ teaserListFromGuideDict :
     -> Page.Guide.Data.Guides
     -> List Page.Shared.Data.Teaser
 teaserListFromGuideDict language guides =
-    Dict.toList (Page.Guide.Data.guidesInPreferredLanguage language guides)
+    Dict.values (Page.Guide.Data.guidesInPreferredLanguage language guides)
         |> List.map
-            (\( _, g ) ->
+            (\g ->
                 { title = g.title
                 , url = Route.toString (Route.Guide g.slug)
                 , summary = g.summary
@@ -69,9 +69,9 @@ teaserListFromStoryDict :
     -> Page.Story.Data.Stories
     -> List Page.Shared.Data.Teaser
 teaserListFromStoryDict language stories =
-    Dict.toList (Page.Story.Data.storiesInPreferredLanguage language stories)
+    Dict.values (Page.Story.Data.storiesInPreferredLanguage language stories)
         |> List.map
-            (\( _, s ) ->
+            (\s ->
                 { title = s.title
                 , url = Route.toString (Route.Story s.slug)
                 , summary = ""

--- a/src/Page/Guides/Data.elm
+++ b/src/Page/Guides/Data.elm
@@ -1,4 +1,4 @@
-module Page.Guides.Data exposing (actionTeaserDecoder, actionTeaserListDecoder, guideTeaserDecoder, guideTeaserListEncoder, guideTeaserListString, internalGuideTeaserDecoder, internalGuideTeaserListDecoder, teaserListFromGuideDict)
+module Page.Guides.Data exposing (actionTeaserDecoder, actionTeaserListDecoder, guideTeaserDecoder, guideTeaserListEncoder, guideTeaserListString, internalGuideTeaserDecoder, internalGuideTeaserListDecoder, teaserListFromGuideDict, teaserListFromStoryDict)
 
 import Dict
 import I18n.Translate exposing (Language)
@@ -7,19 +7,20 @@ import Json.Encode as Encode
 import List
 import Page.Guide.Data
 import Page.Shared.Data
+import Page.Story.Data
 import Route
 
 
-guideTeaserDecoder : Json.Decode.Decoder Page.Shared.Data.GuideTeaser
+guideTeaserDecoder : Json.Decode.Decoder Page.Shared.Data.Teaser
 guideTeaserDecoder =
-    Json.Decode.map4 Page.Shared.Data.GuideTeaser
+    Json.Decode.map4 Page.Shared.Data.Teaser
         (Json.Decode.field "title" Json.Decode.string)
         (Json.Decode.field "basename" Json.Decode.string)
         (Json.Decode.field "summary" Json.Decode.string)
         (Json.Decode.maybe (Json.Decode.field "image" Page.Shared.Data.guideTeaserImageDecoder))
 
 
-guideTeaserEncoder : Page.Shared.Data.GuideTeaser -> Encode.Value
+guideTeaserEncoder : Page.Shared.Data.Teaser -> Encode.Value
 guideTeaserEncoder guideTeaser =
     Encode.object
         [ ( "title", Encode.string guideTeaser.title )
@@ -36,12 +37,12 @@ guideTeaserEncoder guideTeaser =
         ]
 
 
-guideTeaserListString : List Page.Shared.Data.GuideTeaser -> String
+guideTeaserListString : List Page.Shared.Data.Teaser -> String
 guideTeaserListString guideTeaserList =
     Encode.encode 0 (Encode.list guideTeaserEncoder guideTeaserList)
 
 
-guideTeaserListEncoder : List Page.Shared.Data.GuideTeaser -> Encode.Value
+guideTeaserListEncoder : List Page.Shared.Data.Teaser -> Encode.Value
 guideTeaserListEncoder guideTeasers =
     Encode.list guideTeaserEncoder guideTeasers
 
@@ -49,7 +50,7 @@ guideTeaserListEncoder guideTeasers =
 teaserListFromGuideDict :
     Language
     -> Page.Guide.Data.Guides
-    -> List Page.Shared.Data.GuideTeaser
+    -> List Page.Shared.Data.Teaser
 teaserListFromGuideDict language guides =
     Dict.toList (Page.Guide.Data.guidesInPreferredLanguage language guides)
         |> List.map
@@ -63,7 +64,24 @@ teaserListFromGuideDict language guides =
         |> List.sortBy .title
 
 
-guideImagefromTeaserImage : Maybe Page.Guide.Data.Image -> Maybe Page.Shared.Data.GuideTeaserImage
+teaserListFromStoryDict :
+    Language
+    -> Page.Story.Data.Stories
+    -> List Page.Shared.Data.Teaser
+teaserListFromStoryDict language stories =
+    Dict.toList (Page.Story.Data.storiesInPreferredLanguage language stories)
+        |> List.map
+            (\( _, s ) ->
+                { title = s.title
+                , url = Route.toString (Route.Story s.slug)
+                , summary = ""
+                , maybeImage = storyImagefromTeaserImage s.images
+                }
+            )
+        |> List.sortBy .title
+
+
+guideImagefromTeaserImage : Maybe Page.Guide.Data.Image -> Maybe Page.Shared.Data.TeaserImage
 guideImagefromTeaserImage maybeImage =
     case maybeImage of
         Just anImage ->
@@ -73,23 +91,33 @@ guideImagefromTeaserImage maybeImage =
             Just Page.Shared.Data.defaultTeaserImage
 
 
-internalGuideTeaserDecoder : Json.Decode.Decoder Page.Shared.Data.GuideTeaser
+storyImagefromTeaserImage : List Page.Story.Data.Image -> Maybe Page.Shared.Data.TeaserImage
+storyImagefromTeaserImage maybeImages =
+    case List.head maybeImages of
+        Just anImage ->
+            Just { alt = anImage.alt, src = anImage.src }
+
+        Nothing ->
+            Just Page.Shared.Data.defaultTeaserImage
+
+
+internalGuideTeaserDecoder : Json.Decode.Decoder Page.Shared.Data.Teaser
 internalGuideTeaserDecoder =
-    Json.Decode.map4 Page.Shared.Data.GuideTeaser
+    Json.Decode.map4 Page.Shared.Data.Teaser
         (Json.Decode.field "title" Json.Decode.string)
         (Json.Decode.field "url" Json.Decode.string)
         (Json.Decode.field "summary" Json.Decode.string)
         (Json.Decode.maybe (Json.Decode.field "maybeImage" Page.Shared.Data.guideTeaserImageDecoder))
 
 
-internalGuideTeaserListDecoder : Json.Decode.Decoder (List Page.Shared.Data.GuideTeaser)
+internalGuideTeaserListDecoder : Json.Decode.Decoder (List Page.Shared.Data.Teaser)
 internalGuideTeaserListDecoder =
     Json.Decode.list internalGuideTeaserDecoder
 
 
-actionTeaserDecoder : Json.Decode.Decoder Page.Shared.Data.GuideTeaser
+actionTeaserDecoder : Json.Decode.Decoder Page.Shared.Data.Teaser
 actionTeaserDecoder =
-    Json.Decode.map4 Page.Shared.Data.GuideTeaser
+    Json.Decode.map4 Page.Shared.Data.Teaser
         (Json.Decode.at [ "attributes", "title" ] Json.Decode.string)
         (Json.Decode.at [ "attributes", "path", "alias" ] Json.Decode.string
             |> Json.Decode.andThen (\url -> Json.Decode.succeed ("https://www.wildlifetrusts.org" ++ url))
@@ -98,6 +126,6 @@ actionTeaserDecoder =
         (Json.Decode.maybe (Json.Decode.field "image" Page.Shared.Data.guideTeaserImageDecoder))
 
 
-actionTeaserListDecoder : Json.Decode.Decoder (List Page.Shared.Data.GuideTeaser)
+actionTeaserListDecoder : Json.Decode.Decoder (List Page.Shared.Data.Teaser)
 actionTeaserListDecoder =
     Json.Decode.field "data" <| Json.Decode.list actionTeaserDecoder

--- a/src/Page/Guides/View.elm
+++ b/src/Page/Guides/View.elm
@@ -1,4 +1,4 @@
-module Page.Guides.View exposing (view, viewGuideTeaserList)
+module Page.Guides.View exposing (view, viewTeaserList)
 
 import Html.Styled exposing (Html, a, div, h1, img, li, p, text, ul)
 import Html.Styled.Attributes exposing (alt, attribute, css, href, src)
@@ -19,7 +19,7 @@ view model =
         t =
             translate model.language
 
-        teaserList : List Page.Shared.Data.GuideTeaser
+        teaserList : List Page.Shared.Data.Teaser
         teaserList =
             if String.length model.query > 0 then
                 model.search
@@ -49,15 +49,15 @@ view model =
             ]
         , div
             [ css [ contentWrapper ] ]
-            [ viewGuideTeaserList True teaserList
+            [ viewTeaserList True teaserList
             ]
         ]
 
 
-viewGuideTeaser : Bool -> Page.Shared.Data.GuideTeaser -> Html Msg
+viewGuideTeaser : Bool -> Page.Shared.Data.Teaser -> Html Msg
 viewGuideTeaser includeSummary teaser =
     let
-        image : Page.Shared.Data.GuideTeaserImage
+        image : Page.Shared.Data.TeaserImage
         image =
             case teaser.maybeImage of
                 Just i ->
@@ -97,8 +97,8 @@ viewGuideTeaserSummary summary =
         text ""
 
 
-viewGuideTeaserList : Bool -> List Page.Shared.Data.GuideTeaser -> Html Msg
-viewGuideTeaserList includeSummary teasers =
+viewTeaserList : Bool -> List Page.Shared.Data.Teaser -> Html Msg
+viewTeaserList includeSummary teasers =
     if List.length teasers > 0 then
         ul [ css [ Theme.Global.teasersContainerStyle ] ]
             (teasers

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -1,6 +1,6 @@
 module Page.Index exposing (view)
 
-import Css exposing (Style, batch, fontSize, margin2, marginBottom, rem)
+import Css exposing (Style, batch, marginBottom, rem)
 import Html.Styled exposing (Html, div, h1, h2, p, text)
 import Html.Styled.Attributes exposing (css)
 import I18n.Keys exposing (Key(..))
@@ -60,5 +60,5 @@ teaserSubtitleStyle : Style
 teaserSubtitleStyle =
     batch
         [ marginBottom (rem 1)
-        , Theme.FluidScale.fontSize1
+        , Theme.FluidScale.fontSizeLarge
         ]

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -7,7 +7,7 @@ import I18n.Translate exposing (translate)
 import Message exposing (Msg)
 import Page.Guides.Data
 import Page.Guides.View
-import Shared exposing (Model)
+import Shared exposing (Model, shuffleList)
 import Theme.Global exposing (centerContent, contentWrapper, pageColumnBlockStyle, pageColumnStyle, topTwoColumnsWrapperStyle)
 
 
@@ -26,9 +26,13 @@ view model =
                 [ div [ css [ pageColumnStyle ] ]
                     (viewTextColumn t [ WelcomeP1, WelcomeP2, WelcomeP3 ])
                 , div [ css [ pageColumnStyle ] ]
-                    [ List.take 2 (Page.Guides.Data.teaserListFromGuideDict model.language model.content.guides)
+                    [ Page.Guides.Data.teaserListFromGuideDict model.language model.content.guides
+                        |> shuffleList model.seed
+                        |> List.take 2
                         |> Page.Guides.View.viewTeaserList False
-                    , List.take 2 (Page.Guides.Data.teaserListFromStoryDict model.language model.content.stories)
+                    , Page.Guides.Data.teaserListFromStoryDict model.language model.content.stories
+                        |> shuffleList model.seed
+                        |> List.take 2
                         |> Page.Guides.View.viewTeaserList False
                     ]
                 ]

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -1,6 +1,7 @@
 module Page.Index exposing (view)
 
-import Html.Styled exposing (Html, div, h1, p, text)
+import Css exposing (Style, batch, fontSize, margin2, marginBottom, rem)
+import Html.Styled exposing (Html, div, h1, h2, p, text)
 import Html.Styled.Attributes exposing (css)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (translate)
@@ -8,6 +9,7 @@ import Message exposing (Msg)
 import Page.Guides.Data
 import Page.Guides.View
 import Shared exposing (Model, shuffleList)
+import Theme.FluidScale
 import Theme.Global exposing (centerContent, contentWrapper, pageColumnBlockStyle, pageColumnStyle, topTwoColumnsWrapperStyle)
 
 
@@ -26,10 +28,12 @@ view model =
                 [ div [ css [ pageColumnStyle ] ]
                     (viewTextColumn t [ WelcomeP1, WelcomeP2, WelcomeP3 ])
                 , div [ css [ pageColumnStyle ] ]
-                    [ Page.Guides.Data.teaserListFromGuideDict model.language model.content.guides
+                    [ h2 [ css [ teaserSubtitleStyle ] ] [ text (t GuideHighlightsSubtitle) ]
+                    , Page.Guides.Data.teaserListFromGuideDict model.language model.content.guides
                         |> shuffleList model.seed
                         |> List.take 2
                         |> Page.Guides.View.viewTeaserList False
+                    , h2 [ css [ teaserSubtitleStyle ] ] [ text (t StoryHighlightsSubtitle) ]
                     , Page.Guides.Data.teaserListFromStoryDict model.language model.content.stories
                         |> shuffleList model.seed
                         |> List.take 2
@@ -50,3 +54,11 @@ view model =
 viewTextColumn : (Key -> String) -> List Key -> List (Html msg)
 viewTextColumn t paragraphs =
     List.map (\para -> p [ css [ pageColumnBlockStyle ] ] [ text (t para) ]) paragraphs
+
+
+teaserSubtitleStyle : Style
+teaserSubtitleStyle =
+    batch
+        [ marginBottom (rem 1)
+        , Theme.FluidScale.fontSize1
+        ]

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -26,8 +26,10 @@ view model =
                 [ div [ css [ pageColumnStyle ] ]
                     (viewTextColumn t [ WelcomeP1, WelcomeP2, WelcomeP3 ])
                 , div [ css [ pageColumnStyle ] ]
-                    [ List.take 4 (Page.Guides.Data.teaserListFromGuideDict model.language model.content.guides)
-                        |> Page.Guides.View.viewGuideTeaserList False
+                    [ List.take 2 (Page.Guides.Data.teaserListFromGuideDict model.language model.content.guides)
+                        |> Page.Guides.View.viewTeaserList False
+                    , List.take 2 (Page.Guides.Data.teaserListFromStoryDict model.language model.content.stories)
+                        |> Page.Guides.View.viewTeaserList False
                     ]
                 ]
             , div [ css [ pageColumnStyle ] ]

--- a/src/Page/Shared/Data.elm
+++ b/src/Page/Shared/Data.elm
@@ -1,31 +1,31 @@
-module Page.Shared.Data exposing (AudioMeta, GuideTeaser, GuideTeaserImage, VideoMeta, audioDecoder, defaultTeaserImage, guideTeaserImageDecoder, videoDecoder)
+module Page.Shared.Data exposing (AudioMeta, Teaser, TeaserImage, VideoMeta, audioDecoder, defaultTeaserImage, guideTeaserImageDecoder, videoDecoder)
 
 import Json.Decode
 
 
-type alias GuideTeaserImage =
+type alias TeaserImage =
     { src : String, alt : String }
 
 
-defaultTeaserImage : GuideTeaserImage
+defaultTeaserImage : TeaserImage
 defaultTeaserImage =
     { src = "/images/default-guide-image.jpg", alt = "" }
 
 
-guideTeaserImageDecoder : Json.Decode.Decoder GuideTeaserImage
+guideTeaserImageDecoder : Json.Decode.Decoder TeaserImage
 guideTeaserImageDecoder =
-    Json.Decode.map2 GuideTeaserImage
+    Json.Decode.map2 TeaserImage
         (Json.Decode.field "src" Json.Decode.string)
         (Json.Decode.field "alt" Json.Decode.string)
 
 
-type alias GuideTeaser =
+type alias Teaser =
     { title : String
 
     -- This will maybe turn into Url.Url when we include external resources
     , url : String
     , summary : String
-    , maybeImage : Maybe GuideTeaserImage
+    , maybeImage : Maybe TeaserImage
     }
 
 

--- a/src/Page/Story/Data.elm
+++ b/src/Page/Story/Data.elm
@@ -1,11 +1,10 @@
-module Page.Story.Data exposing (Image, Stories, Story, StoryTeaser, allStoryTeaserList, defaultStoryImageSrc, storyFromSlug, storyLanguageDictDecoder)
+module Page.Story.Data exposing (Image, Stories, Story, StoryTeaser, allStoryTeaserList, defaultStoryImageSrc, storiesInPreferredLanguage, storyFromSlug, storyLanguageDictDecoder)
 
 import Dict exposing (Dict)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..), translate)
 import Json.Decode
 import Json.Decode.Extra
-import Page.Guides.Data
 import Page.Shared.Data
 
 
@@ -22,7 +21,7 @@ type alias Story =
     , maybeGroupOrIndividual : Maybe String
     , images : List Image
     , fullTextMarkdown : String
-    , relatedGuideList : List Page.Shared.Data.GuideTeaser
+    , relatedGuideList : List Page.Shared.Data.Teaser
     }
 
 
@@ -82,7 +81,7 @@ storyDictDecoder =
                 (Json.Decode.field "content" Json.Decode.string |> Json.Decode.Extra.withDefault "")
             |> Json.Decode.Extra.andMap
                 (Json.Decode.field "relatedGuideList"
-                    (Json.Decode.list Page.Guides.Data.guideTeaserDecoder)
+                    (Json.Decode.list guideTeaserDecoder)
                     |> Json.Decode.Extra.withDefault []
                 )
         )
@@ -174,3 +173,12 @@ translationsFromSlug storyDict { slug, title, images } =
         -- Means this story is only on one language.
         Nothing ->
             { title = title, maybeImage = List.head images }
+
+
+guideTeaserDecoder : Json.Decode.Decoder Page.Shared.Data.Teaser
+guideTeaserDecoder =
+    Json.Decode.map4 Page.Shared.Data.Teaser
+        (Json.Decode.field "title" Json.Decode.string)
+        (Json.Decode.field "basename" Json.Decode.string)
+        (Json.Decode.field "summary" Json.Decode.string)
+        (Json.Decode.maybe (Json.Decode.field "image" Page.Shared.Data.guideTeaserImageDecoder))

--- a/src/Page/Story/View.elm
+++ b/src/Page/Story/View.elm
@@ -36,7 +36,7 @@ view story =
                 , div [ css [ pageColumnStyle ] ]
                     (markdownToHtml story.fullTextMarkdown)
                 ]
-            , viewColumnWrapper (Page.Guides.View.viewGuideTeaserList False story.relatedGuideList)
+            , viewColumnWrapper (Page.Guides.View.viewTeaserList False story.relatedGuideList)
             ]
         ]
 

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -17,7 +17,7 @@ type alias Model =
     , cookieState : CookieState
     , language : Language
     , content : Content
-    , search : List Page.Shared.Data.GuideTeaser
+    , search : List Page.Shared.Data.Teaser
     , query : String
     , externalActions : Request
     }
@@ -48,7 +48,7 @@ type alias Content =
 type Request
     = Failure
     | Loading
-    | Success (List Page.Shared.Data.GuideTeaser)
+    | Success (List Page.Shared.Data.Teaser)
 
 
 contentDictDecoder : Json.Decode.Value -> Content

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -1,5 +1,6 @@
-module Shared exposing (Content, CookieState, Model, Request(..), contentDictDecoder)
+module Shared exposing (Content, CookieState, Model, Request(..), contentDictDecoder, shuffleList)
 
+import Array
 import Browser.Navigation
 import Dict exposing (Dict)
 import I18n.Translate exposing (Language)
@@ -8,6 +9,7 @@ import Page.Data
 import Page.Guide.Data
 import Page.Shared.Data
 import Page.Story.Data
+import Random
 import Route exposing (Route)
 
 
@@ -20,6 +22,7 @@ type alias Model =
     , search : List Page.Shared.Data.Teaser
     , query : String
     , externalActions : Request
+    , seed : Maybe Random.Seed
     }
 
 
@@ -74,3 +77,40 @@ flagsDictDecoder =
         (Json.Decode.field "guides" Page.Guide.Data.guideLanguageDictDecoder)
         (Json.Decode.field "pages" Page.Data.pageLanguageDictDecoder)
         (Json.Decode.field "stories" Page.Story.Data.storyLanguageDictDecoder)
+
+
+shuffleList : Maybe Random.Seed -> List a -> List a
+shuffleList seed list =
+    case seed of
+        Just aSeed ->
+            shuffleListHelper aSeed list []
+
+        Nothing ->
+            []
+
+
+shuffleListHelper : Random.Seed -> List a -> List a -> List a
+shuffleListHelper seed source result =
+    if List.isEmpty source then
+        result
+
+    else
+        let
+            indexGenerator =
+                Random.int 0 (List.length source - 1)
+
+            ( index, nextSeed ) =
+                Random.step indexGenerator seed
+
+            valAtIndex =
+                Array.get index (Array.fromList source)
+
+            sourceWithoutIndex =
+                List.take index source ++ List.drop (index + 1) source
+        in
+        case valAtIndex of
+            Just val ->
+                shuffleListHelper nextSeed sourceWithoutIndex (val :: result)
+
+            Nothing ->
+                result

--- a/src/Theme/HeaderTemplate.elm
+++ b/src/Theme/HeaderTemplate.elm
@@ -66,7 +66,7 @@ searchInput model =
         t =
             I18n.Translate.translate model.language
 
-        teaserList : List Page.Shared.Data.GuideTeaser
+        teaserList : List Page.Shared.Data.Teaser
         teaserList =
             if model.language == Welsh then
                 Page.Guides.Data.teaserListFromGuideDict model.language model.content.guides

--- a/tests/Story.elm
+++ b/tests/Story.elm
@@ -34,7 +34,13 @@ suite =
             , slug = "slug"
             , maybeLocation = Just "Test location"
             , maybeGroupOrIndividual = Just "Test group"
-            , images = [ { src = "/images/wildlife-trust-logo.png", alt = "placeholder" } ]
+            , images =
+                [ { src = "/images/wildlife-trust-logo.png"
+                  , alt = "placeholder"
+                  , maybeCaption = Just "caption"
+                  , maybeCredit = Just "credit"
+                  }
+                ]
             , relatedGuideList =
                 [ { title = "A related guide"
                   , url = "/a-guide"

--- a/tests/TestData.elm
+++ b/tests/TestData.elm
@@ -242,7 +242,7 @@ singleActionFromAPI =
 """
 
 
-teaserFromResult : Page.Shared.Data.GuideTeaser
+teaserFromResult : Page.Shared.Data.Teaser
 teaserFromResult =
     { title = "How to help wildlife at school"
     , url = "https://www.wildlifetrusts.org/actions/how-help-wildlife-school"
@@ -251,7 +251,7 @@ teaserFromResult =
     }
 
 
-teaserFromResult2 : Page.Shared.Data.GuideTeaser
+teaserFromResult2 : Page.Shared.Data.Teaser
 teaserFromResult2 =
     { title = "How to make a coastal garden"
     , url = "https://www.wildlifetrusts.org/actions/how-make-coastal-garden"


### PR DESCRIPTION
Fixes #256

## Description

- Aargh this was more complicated than I realised! Makes use of elm's random library to generate a random seed upon init to randomly assign highlighted stories and guides to the homepage
- refactors `GuideTeasers` into just `Teasers` to reflect that they are also used by stories in some places for consistency and adds some helpers to allow stories to be used in this way too on the homepage
- Adds a subtitle for each group

It does not deal with StoryTeasers, which still exist in other pages and which may now be able to be replaced by just the Teaser - I started trying to refactor this too but ran very quickly into circular imports and so left!

@geeksforsocialchange/developers
