### PR TITLE
improve font weights and guide teaser image whitespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,10 +18,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Rubik:wght@300&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300;0,400;0,500;0,700;0,800;0,900;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
       rel="stylesheet"
     />
-
     <!-- ludicrous font -->
     <style>
       @font-face {

--- a/src/Page/Guides/View.elm
+++ b/src/Page/Guides/View.elm
@@ -1,5 +1,6 @@
 module Page.Guides.View exposing (view, viewGuideTeaserList)
 
+import Css exposing (fontWeight, int)
 import Html.Styled exposing (Html, a, div, h1, img, li, p, text, ul)
 import Html.Styled.Attributes exposing (alt, attribute, css, href, src)
 import I18n.Keys exposing (Key(..))
@@ -77,7 +78,7 @@ viewGuideTeaser includeSummary teaser =
             ]
             []
         , p [ css [ Theme.Global.teaserRowStyle ] ]
-            [ a [ href teaser.url ] [ text teaser.title ] ]
+            [ a [ css [ fontWeight (int 600) ], href teaser.url ] [ text teaser.title ] ]
         , if includeSummary then
             viewGuideTeaserSummary teaser.summary
 

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -280,6 +280,7 @@ teaserImageStyle =
         , property "aspect-ratio" "1/1"
         , property "object-fit" "cover"
         , width (pct 100)
+        , marginBottom (rem 1)
         ]
 
 


### PR DESCRIPTION
partial improvement of  #219

## Description

- we were only importing light fonts for rubik
- add a little bit of whitespace between image and title of guide teasers

@geeksforsocialchange/developers
