### PR TITLE
Update layout at top of guide page

### DIFF
--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -1,7 +1,7 @@
 module Page.Guide.View exposing (view)
 
-import Css exposing (Style, batch, borderBottom3, center, column, displayFlex, flexDirection, flexWrap, justifyContent, listStyle, marginBottom, marginTop, maxWidth, none, paddingLeft, px, rem, solid, wrap, zero)
-import Html.Styled exposing (Html, a, div, h2, img, li, text, ul)
+import Css exposing (Style, auto, batch, borderBottom3, center, color, column, displayFlex, flexDirection, flexWrap, justifyContent, listStyle, margin2, marginBottom, marginTop, maxWidth, none, paddingLeft, px, rem, solid, wrap, zero)
+import Html.Styled exposing (Html, a, div, h2, img, li, p, text, ul)
 import Html.Styled.Attributes exposing (alt, css, href, src)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..), translate)
@@ -12,8 +12,7 @@ import Page.Shared.Data
 import Page.Shared.View
 import Page.Story.Data
 import Route exposing (Route(..))
-import Theme.FluidScale exposing (fontSizeBase)
-import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, pageColumnBlockStyle, pageColumnStyle, primaryHeader, teal, teaserImageStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, pageColumnBlockStyle, pageColumnStyle, primaryHeader, purple, teal, teaserImageStyle, topTwoColumnsWrapperStyle)
 import Theme.Markdown exposing (markdownToHtml)
 
 
@@ -23,14 +22,13 @@ view language guide allGuides allStories =
         [ div [ css [ outerBorderStyle ] ]
             [ div
                 [ css [ centerContent ] ]
-                [ primaryHeader [] guide.title
-                , viewSummaryImageRow guide
+                [ primaryHeader [ css [ guideTitleStyle ] ] guide.title
                 ]
             ]
         , div
             [ css [ centerContent ] ]
             [ viewRow
-                ( markdownToHtml guide.fullTextMarkdown
+                ( viewImageColumn guide
                 , [ viewMaybeVideo guide.maybeVideo
                   , viewMaybeAudio guide.maybeAudio
                   , viewRelatedGuideTeasers language guide.relatedGuideList allGuides
@@ -41,8 +39,8 @@ view language guide allGuides allStories =
         ]
 
 
-viewSummaryImageRow : Page.Guide.Data.Guide -> Html Msg
-viewSummaryImageRow guide =
+viewImageColumn : Page.Guide.Data.Guide -> List (Html Msg)
+viewImageColumn guide =
     let
         image : Page.Guide.Data.Image
         image =
@@ -53,16 +51,17 @@ viewSummaryImageRow guide =
                 Nothing ->
                     Page.Guide.Data.defaultGuideImage
     in
-    viewRow
-        ( [ div [ css [ guideSummaryStyle ] ] [ text guide.summary ] ]
-        , [ img [ css [ featureImageStyle ], src image.src, alt image.alt ] [] ]
+    [ div []
+        [ img [ css [ featureImageStyle ], src image.src, alt image.alt ] []
         , case image.maybeCredit of
             Just aCredit ->
-                [ text aCredit ]
+                p [ css [ imageCaptionStyle ] ] [ text aCredit ]
 
             Nothing ->
-                [ text "" ]
-        )
+                text ""
+        ]
+    , div [] (markdownToHtml guide.fullTextMarkdown)
+    ]
 
 
 viewRow : ( List (Html Msg), List (Html Msg), List (Html Msg) ) -> Html Msg
@@ -246,11 +245,6 @@ storyteaserContainerStyle =
         ]
 
 
-guideSummaryStyle : Style
-guideSummaryStyle =
-    fontSizeBase
-
-
 listStyleNone : Style
 listStyleNone =
     batch
@@ -265,3 +259,14 @@ outerBorderStyle =
         [ borderBottom3 (rem 0.5) solid teal
         , marginBottom (rem 2)
         ]
+
+
+imageCaptionStyle : Style
+imageCaptionStyle =
+    batch
+        [ color purple, margin2 (rem 1) (rem 0) ]
+
+
+guideTitleStyle : Style
+guideTitleStyle =
+    batch [ margin2 (rem 0) auto ]

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -1,6 +1,6 @@
 module Page.Guide.View exposing (view)
 
-import Css exposing (Style, batch, center, column, displayFlex, flexDirection, flexWrap, fontFamilies, justifyContent, listStyle, marginTop, maxWidth, none, padding2, paddingLeft, px, wrap, zero)
+import Css exposing (Style, batch, borderBottom3, center, column, displayFlex, flexDirection, flexWrap, fontFamilies, justifyContent, listStyle, marginBottom, marginTop, maxWidth, none, padding2, paddingLeft, px, rem, solid, wrap, zero)
 import Html.Styled exposing (Html, a, div, h1, h2, img, li, text, ul)
 import Html.Styled.Attributes exposing (alt, css, href, src)
 import I18n.Keys exposing (Key(..))
@@ -13,23 +13,31 @@ import Page.Shared.View
 import Page.Story.Data
 import Route exposing (Route(..))
 import Theme.FluidScale exposing (fontSize1)
-import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, pageColumnBlockStyle, pageColumnStyle, roundedCornerStyle, teaserImageStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, pageColumnBlockStyle, pageColumnStyle, teal, teaserImageStyle, topTwoColumnsWrapperStyle)
 import Theme.Markdown exposing (markdownToHtml)
 
 
 view : Language -> Page.Guide.Data.Guide -> List Page.Guide.Data.GuideListItem -> List Page.Story.Data.StoryTeaser -> Html Msg
 view language guide allGuides allStories =
-    div [ css [ centerContent ] ]
-        [ h1 [ css [ guideTitleStyle ] ] [ text guide.title ]
-        , viewSummaryImageRow guide
-        , viewRow
-            ( markdownToHtml guide.fullTextMarkdown
-            , [ viewMaybeVideo guide.maybeVideo
-              , viewMaybeAudio guide.maybeAudio
-              , viewRelatedGuideTeasers language guide.relatedGuideList allGuides
-              ]
-            , [ viewRelatedStoryTeasers language guide.relatedStoryList allStories ]
-            )
+    div []
+        [ div [ css [ outerBorderStyle ] ]
+            [ div
+                [ css [ centerContent ] ]
+                [ h1 [ css [ guideTitleStyle ] ] [ text guide.title ]
+                , viewSummaryImageRow guide
+                ]
+            ]
+        , div
+            [ css [ centerContent ] ]
+            [ viewRow
+                ( markdownToHtml guide.fullTextMarkdown
+                , [ viewMaybeVideo guide.maybeVideo
+                  , viewMaybeAudio guide.maybeAudio
+                  , viewRelatedGuideTeasers language guide.relatedGuideList allGuides
+                  ]
+                , [ viewRelatedStoryTeasers language guide.relatedStoryList allStories ]
+                )
+            ]
         ]
 
 
@@ -212,8 +220,7 @@ viewStoryImage maybeImage =
         [ alt image.alt
         , src image.src
         , css
-            [ roundedCornerStyle
-            , teaserImageStyle
+            [ teaserImageStyle
             ]
         ]
         []
@@ -254,4 +261,12 @@ listStyleNone =
     batch
         [ listStyle none
         , paddingLeft zero
+        ]
+
+
+outerBorderStyle : Style
+outerBorderStyle =
+    batch
+        [ borderBottom3 (rem 0.5) solid teal
+        , marginBottom (rem 2)
         ]

--- a/src/Page/Guides/View.elm
+++ b/src/Page/Guides/View.elm
@@ -65,8 +65,7 @@ viewGuideTeaser includeSummary teaser =
             [ alt image.alt
             , src image.src
             , css
-                [ Theme.Global.roundedCornerStyle
-                , Theme.Global.teaserImageStyle
+                [ Theme.Global.teaserImageStyle
                 ]
             ]
             []

--- a/src/Page/Story/View.elm
+++ b/src/Page/Story/View.elm
@@ -6,7 +6,7 @@ import Html.Styled.Attributes exposing (alt, css, src)
 import Message exposing (Msg)
 import Page.Guides.View
 import Page.Story.Data
-import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, pageColumnStyle, roundedCornerStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, pageColumnStyle, topTwoColumnsWrapperStyle)
 import Theme.Markdown exposing (markdownToHtml)
 
 
@@ -46,7 +46,7 @@ viewImages imageList =
     List.map
         (\image ->
             div []
-                [ img [ src image.src, alt image.alt, css [ roundedCornerStyle, featureImageStyle ] ] []
+                [ img [ src image.src, alt image.alt, css [ featureImageStyle ] ] []
                 , viewImageCaption (maybeCaptions image.maybeCaption image.maybeCredit)
                 ]
         )

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,6 +1,6 @@
 module Theme.Global exposing (borderWrapper, centerContent, contentWrapper, featureImageStyle, globalStyles, lightTeal, listStyleNone, pageColumnBlockStyle, pageColumnStyle, purple, roundedCornerStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, teasersContainerStyle, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
 
-import Css exposing (Color, Style, alignItems, auto, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, border3, borderBottomRightRadius, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contain, contentBox, cover, cursor, display, displayFlex, em, ex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, inlineBlock, int, justifyContent, lastChild, listStyle, margin, margin2, margin3, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, paddingLeft, pct, pointer, property, pseudoElement, px, rem, row, solid, spaceBetween, textDecoration, url, width, wrap, zero)
+import Css exposing (Color, Style, alignItems, auto, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, border3, borderBottomRightRadius, borderRadius4, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contain, contentBox, cover, cursor, display, displayFlex, em, ex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, inlineBlock, int, justifyContent, lastChild, listStyle, margin, margin2, margin3, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, paddingLeft, pct, pointer, property, pseudoElement, px, rem, row, solid, spaceBetween, textDecoration, url, width, wrap, zero)
 import Css.Global exposing (global, typeSelector)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html)
@@ -91,9 +91,7 @@ roundedCornerValue =
 roundedCornerStyle : Style
 roundedCornerStyle =
     batch
-        [ borderTopLeftRadius (rem roundedCornerValue)
-        , borderTopRightRadius (rem roundedCornerValue)
-        , borderBottomRightRadius (rem roundedCornerValue)
+        [ borderRadius4 (rem roundedCornerValue) (rem roundedCornerValue) (rem roundedCornerValue) (rem 0)
         , overflow hidden
         ]
 
@@ -246,6 +244,7 @@ featureImageStyle =
         [ width (pct 100)
         , height auto
         , maxWidth (px (maxSmallDesktop / 3))
+        , roundedCornerStyle
         , teaserRowStyle
         ]
 
@@ -259,6 +258,7 @@ teaserImageStyle =
         , maxWidth (px (maxMobile / 3))
         , property "aspect-ratio" "1/1"
         , property "object-fit" "cover"
+        , roundedCornerStyle
         , width (pct 100)
         ]
 
@@ -289,6 +289,7 @@ contentWrapper =
         , flexDirection column
         , flexWrap noWrap
         , justifyContent center
+        , width (pct 100)
         , withMediaTabletLandscapeUp
             [ alignItems flexStart
             , flexDirection row


### PR DESCRIPTION
Partially addresses #217 

## Description

- Adds a divider to the top of the guide page and moves some content around
- Changes display of image and caption

@geeksforsocialchange/developers
