### PR TITLE
print version of guide

### DIFF
--- a/content/guides/en/test-guide-with-all-content.md
+++ b/content/guides/en/test-guide-with-all-content.md
@@ -20,7 +20,7 @@ category: admin-and-info
 
 \[﻿cCc] for placeholder copy sweep
 
-Lorem ipsum dolor sit amet consectetur adipiscing elit dictumst odio class mauris, nascetur curae pellentesque laoreet nullam hac nisl ante lobortis posuere, malesuada hendrerit pharetra curabitur mus quam dapibus convallis condimentum suscipit. Fusce pretium non sociosqu sem himenaeos rutrum turpis praesent laoreet fermentum, viverra mollis cursus suspendisse vel suscipit id quisque magna, aliquam eget neque et etiam metus montes blandit feugiat. Torquent ante odio suspendisse sagittis leo ullamcorper facilisis mattis nostra faucibus, donec aliquet integer ad quam sed sodales sociosqu bibendum tempor, posuere massa volutpat condimentum felis neque nisl interdum elementum.
+[Lorem ipsum](www.website.com) dolor sit amet consectetur adipiscing elit dictumst odio class mauris, nascetur curae pellentesque laoreet nullam hac nisl ante lobortis posuere, malesuada hendrerit pharetra curabitur mus quam dapibus convallis condimentum suscipit. Fusce pretium non sociosqu sem himenaeos rutrum turpis praesent laoreet fermentum, viverra mollis cursus suspendisse vel suscipit id quisque magna, aliquam eget neque et etiam metus montes blandit feugiat. Torquent ante odio suspendisse sagittis leo ullamcorper facilisis mattis nostra faucibus, donec aliquet integer ad quam sed sodales sociosqu bibendum tempor, posuere massa volutpat condimentum felis neque nisl interdum elementum.
 
 - l﻿ist item one
 - l﻿ist item two

--- a/src/CookieBanner.elm
+++ b/src/CookieBanner.elm
@@ -8,18 +8,18 @@ import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language, translate)
 import Message exposing (Msg(..))
 import Shared exposing (CookieState)
-import Theme.Global exposing (centerContent, lightTeal, purple, white, withMediaMobileUp)
+import Theme.Global exposing (centerContent, hideFromPrint, lightTeal, purple, white, withMediaMobileUp)
 
 
 viewCookieBanner : Language -> CookieState -> Html Msg
 viewCookieBanner language cookieState =
     if cookieState.cookieBannerIsOpen then
-        div [ css [ viewCookieBannerStyles ] ]
+        div [ css [ viewCookieBannerStyles, hideFromPrint ] ]
             [ viewCookieBannerContent language
             ]
 
     else
-        div [ css [ viewCookieButtonStyles ] ]
+        div [ css [ viewCookieButtonStyles, hideFromPrint ] ]
             [ viewCookieSettingsButton language
             ]
 

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -145,6 +145,15 @@ enStrings key =
         RelatedStoriesHeading ->
             "Real Stories"
 
+        GuidePrintHeader ->
+            "Printable verison"
+
+        GuideButtonText ->
+            "Click here"
+
+        GuideParagraphText ->
+            "for a printable version of this page, which you can easily share with groups or anyone who does not have digital access"
+
         ---
         -- Guides Page
         ---

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -45,6 +45,9 @@ type Key
       --- Guide Page
     | RelatedGuidesHeading
     | RelatedStoriesHeading
+    | GuidePrintHeader
+    | GuideButtonText
+    | GuideParagraphText
       --- Guides Page
     | GuidesTitle
     | GuidesMetaDescription

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -228,6 +228,9 @@ update msg model =
         NoOp ->
             ( model, Cmd.none )
 
+        Print ->
+            ( model, Page.Guide.View.print () )
+
 
 openCookieBanner : CookieState -> CookieState
 openCookieBanner oldState =

--- a/src/Message.elm
+++ b/src/Message.elm
@@ -18,3 +18,4 @@ type Msg
     | GotActions (Result Http.Error (List Page.Shared.Data.Teaser))
     | UpdateSeed Random.Seed
     | NoOp
+    | Print

--- a/src/Message.elm
+++ b/src/Message.elm
@@ -17,5 +17,5 @@ type Msg
     | SearchChanged (List Page.Shared.Data.Teaser) String
     | GotActions (Result Http.Error (List Page.Shared.Data.Teaser))
     | UpdateSeed Random.Seed
-    | NoOp
     | Print
+    | NoOp

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -12,14 +12,14 @@ import Page.Shared.Data
 import Page.Shared.View
 import Page.Story.Data
 import Route exposing (Route(..))
-import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, pageColumnBlockStyle, pageColumnStyle, primaryHeader, purple, teal, teaserImageStyle, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, hideFromPrint, pageColumnBlockStyle, pageColumnStyle, primaryHeader, purple, teal, teaserImageStyle, topTwoColumnsWrapperStyle, withMediaPrint)
 import Theme.Markdown exposing (markdownToHtml)
 
 
 view : Language -> Page.Guide.Data.Guide -> List Page.Guide.Data.GuideListItem -> List Page.Story.Data.StoryTeaser -> Html Msg
 view language guide allGuides allStories =
     div []
-        [ div [ css [ outerBorderStyle ] ]
+        [ div [ css [ outerBorderStyle, withMediaPrint <| Just [ marginBottom (rem 0) ] ] ]
             [ div
                 [ css [ centerContent ] ]
                 [ primaryHeader [ css [ guideTitleStyle ] ] guide.title
@@ -77,7 +77,7 @@ viewImageColumn language guide =
                 _ ->
                     CategoryAdminAndInfoName
     in
-    [ div []
+    [ div [ css [ hideFromPrint ] ]
         [ img [ css [ featureImageStyle ], src image.src, alt image.alt ] []
         , case image.maybeCredit of
             Just aCredit ->
@@ -86,7 +86,7 @@ viewImageColumn language guide =
             Nothing ->
                 text ""
         ]
-    , div [] [ text (t InCategory ++ t (categorySlugToKey guide.categorySlug)) ]
+    , div [ css [ hideFromPrint ] ] [ text (t InCategory ++ t (categorySlugToKey guide.categorySlug)) ]
     , div [] (markdownToHtml guide.fullTextMarkdown)
     ]
 
@@ -143,7 +143,7 @@ viewRelatedGuideTeasers language guideTitleList allGuidesSlugTitleList =
             t =
                 translate language
         in
-        div []
+        div [ css [ hideFromPrint ] ]
             [ h2 [] [ text (t RelatedGuidesHeading) ]
             , ul [ css [ listStyleNone ] ]
                 (List.map
@@ -203,7 +203,7 @@ viewRelatedStoryTeasers language storyTitleList allStoryTeasers =
             t =
                 translate language
         in
-        div []
+        div [ css [ hideFromPrint ] ]
             [ h2 [ css [ marginTop zero ] ] [ text (t RelatedStoriesHeading) ]
             , div [ css [ viewStoryTeasersStyle ] ]
                 (relatedStoryItems

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -1,12 +1,13 @@
-module Page.Guide.View exposing (view)
+port module Page.Guide.View exposing (print, view)
 
 import Css exposing (Style, auto, batch, borderBottom3, center, color, column, displayFlex, flexDirection, flexWrap, justifyContent, listStyle, margin2, marginBottom, marginTop, maxWidth, none, paddingLeft, px, rem, solid, wrap, zero)
-import Html.Styled exposing (Html, a, div, h2, img, li, p, text, ul)
+import Html.Styled exposing (Html, a, button, div, h2, img, li, p, text, ul)
 import Html.Styled.Attributes exposing (alt, css, href, src)
+import Html.Styled.Events exposing (onClick)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..), translate)
 import List
-import Message exposing (Msg)
+import Message exposing (Msg(..))
 import Page.Guide.Data
 import Page.Shared.Data
 import Page.Shared.View
@@ -31,6 +32,7 @@ view language guide allGuides allStories =
                 ( viewImageColumn language guide
                 , [ viewMaybeVideo guide.maybeVideo
                   , viewMaybeAudio guide.maybeAudio
+                  , viewPrintGuide language
                   , viewRelatedGuideTeasers language guide.relatedGuideList allGuides
                   ]
                 , [ viewRelatedStoryTeasers language guide.relatedStoryList allStories ]
@@ -247,6 +249,19 @@ viewStoryImage maybeImage =
         []
 
 
+viewPrintGuide : Language -> Html Msg
+viewPrintGuide language =
+    div [ css [ hideFromPrint ] ]
+        [ h2 []
+            [ text "print some stuff" ]
+        , p
+            []
+            [ button [ onClick Print ] [ text "click here" ]
+            , text "for printable version of this page  which you can easily share with groups or anyone who does not have digital access."
+            ]
+        ]
+
+
 viewStoryTeasersStyle : Style
 viewStoryTeasersStyle =
     batch
@@ -292,3 +307,6 @@ imageCaptionStyle =
 guideTitleStyle : Style
 guideTitleStyle =
     batch [ margin2 (rem 0) auto ]
+
+
+port print : () -> Cmd msg

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -1,6 +1,6 @@
 port module Page.Guide.View exposing (print, view)
 
-import Css exposing (Style, auto, batch, borderBottom3, center, color, column, displayFlex, flexDirection, flexWrap, justifyContent, listStyle, margin2, marginBottom, marginTop, maxWidth, none, paddingLeft, px, rem, solid, wrap, zero)
+import Css exposing (Style, auto, backgroundColor, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, border, borderBottom3, center, color, column, contain, display, displayFlex, em, ex, flexDirection, flexWrap, fontFamilies, height, inlineBlock, justifyContent, listStyle, margin2, marginBottom, marginLeft, marginTop, maxWidth, noRepeat, none, padding, paddingLeft, paddingRight, property, pseudoElement, px, rem, solid, url, width, wrap, zero)
 import Html.Styled exposing (Html, a, button, div, h2, img, li, p, text, ul)
 import Html.Styled.Attributes exposing (alt, css, href, src)
 import Html.Styled.Events exposing (onClick)
@@ -13,7 +13,7 @@ import Page.Shared.Data
 import Page.Shared.View
 import Page.Story.Data
 import Route exposing (Route(..))
-import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, hideFromPrint, pageColumnBlockStyle, pageColumnStyle, primaryHeader, purple, teal, teaserImageStyle, topTwoColumnsWrapperStyle, withMediaPrint)
+import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, hideFromPrint, lightTeal, pageColumnBlockStyle, pageColumnStyle, primaryHeader, purple, teal, teaserImageStyle, topTwoColumnsWrapperStyle, withMediaPrint)
 import Theme.Markdown exposing (markdownToHtml)
 
 
@@ -251,13 +251,18 @@ viewStoryImage maybeImage =
 
 viewPrintGuide : Language -> Html Msg
 viewPrintGuide language =
+    let
+        t : Key -> String
+        t =
+            translate language
+    in
     div [ css [ hideFromPrint ] ]
         [ h2 []
-            [ text "print some stuff" ]
+            [ text (t GuidePrintHeader) ]
         , p
             []
-            [ button [ onClick Print ] [ text "click here" ]
-            , text "for printable version of this page  which you can easily share with groups or anyone who does not have digital access."
+            [ button [ onClick Print, css [ printButtonStyle ] ] [ text (t GuideButtonText) ]
+            , text (t GuideParagraphText)
             ]
         ]
 
@@ -307,6 +312,29 @@ imageCaptionStyle =
 guideTitleStyle : Style
 guideTitleStyle =
     batch [ margin2 (rem 0) auto ]
+
+
+printButtonStyle : Style
+printButtonStyle =
+    batch
+        [ backgroundColor lightTeal
+        , border (rem 0)
+        , fontFamilies [ "Rubik", "sans-serif" ]
+        , padding (rem 0)
+        , paddingRight (rem 0.2)
+        , pseudoElement "after"
+            [ backgroundImage
+                (url "/images/arrow.svg")
+            , backgroundSize contain
+            , backgroundPosition center
+            , backgroundRepeat noRepeat
+            , display inlineBlock
+            , property "content" "' '"
+            , height (ex 1.5)
+            , width (em 1.0)
+            , marginLeft (em 0.3)
+            ]
+        ]
 
 
 port print : () -> Cmd msg

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -20,7 +20,7 @@ import Theme.Markdown exposing (markdownToHtml)
 view : Language -> Page.Guide.Data.Guide -> List Page.Guide.Data.GuideListItem -> List Page.Story.Data.StoryTeaser -> Html Msg
 view language guide allGuides allStories =
     div []
-        [ div [ css [ outerBorderStyle, withMediaPrint <| Just [ marginBottom (rem 0) ] ] ]
+        [ div [ css [ outerBorderStyle, withMediaPrint (Just [ marginBottom (rem 0) ]) ] ]
             [ div
                 [ css [ centerContent ] ]
                 [ primaryHeader [ css [ guideTitleStyle ] ] guide.title

--- a/src/Page/Shared/View.elm
+++ b/src/Page/Shared/View.elm
@@ -5,11 +5,12 @@ import Html.Styled exposing (Html, div, iframe, text)
 import Html.Styled.Attributes exposing (attribute, autoplay, css, src, title)
 import Message exposing (Msg)
 import Page.Shared.Data
+import Theme.Global exposing (hideFromPrint)
 
 
 viewVideo : Page.Shared.Data.VideoMeta -> Html Msg
 viewVideo videoMeta =
-    div [ css [ videoContainerStyle ] ]
+    div [ css [ videoContainerStyle, hideFromPrint ] ]
         [ iframe
             [ src videoMeta.src
             , attribute "frameborder" "0"
@@ -25,7 +26,7 @@ viewVideo videoMeta =
 viewAudio : Page.Shared.Data.AudioMeta -> Html Msg
 viewAudio _ =
     div
-        [ css [ embeddedVideoStyle ]
+        [ css [ embeddedVideoStyle, hideFromPrint ]
         ]
         [ text "[fFf] render audio player" ]
 

--- a/src/Theme/FooterTemplate.elm
+++ b/src/Theme/FooterTemplate.elm
@@ -7,7 +7,7 @@ import Html.Styled.Attributes exposing (css, href, src)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..), translate)
 import Theme.FluidScale
-import Theme.Global exposing (centerContent, lightTeal, listStyleNone, purple, teal, white, withMediaMobileUp, withMediaTabletPortraitUp)
+import Theme.Global exposing (centerContent, hideFromPrint, lightTeal, listStyleNone, purple, teal, white, withMediaMobileUp, withMediaTabletPortraitUp)
 
 
 view : Language -> Html msg
@@ -18,7 +18,7 @@ view language =
             translate language
     in
     footer
-        []
+        [ css [ hideFromPrint ] ]
         [ div [ css [ navBorderStyle ] ]
             [ nav [ css [ centerContent, footerNavStyle ] ]
                 (List.map

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,8 +1,8 @@
-module Theme.Global exposing (borderWrapper, centerContent, contentWrapper, featureImageStyle, globalStyles, lightTeal, listStyleNone, pageColumnBlockStyle, pageColumnStyle, primaryHeader, purple, roundedCornerStyle, screenReaderOnly, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, topTwoColumnsWrapperStyle, white, withMediaDesktopUp, withMediaMobileUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+module Theme.Global exposing (borderWrapper, centerContent, contentWrapper, featureImageStyle, globalStyles, hideFromPrint, lightTeal, listStyleNone, pageColumnBlockStyle, pageColumnStyle, primaryHeader, purple, roundedCornerStyle, screenReaderOnly, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, topTwoColumnsWrapperStyle, white, withMediaDesktopUp, withMediaMobileUp, withMediaPrint, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 
-import Css exposing (Color, Style, absolute, alignItems, auto, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, border3, borderBottomRightRadius, borderRadius4, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contain, contentBox, cover, cursor, display, displayFlex, em, ex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, inlineBlock, int, justifyContent, lastChild, left, listStyle, margin, margin2, margin3, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, paddingLeft, pct, pointer, position, property, pseudoElement, px, rem, row, solid, textDecoration, top, url, width, zero)
+import Css exposing (Color, Style, absolute, alignItems, auto, backgroundColor, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, border, border3, borderBottomRightRadius, borderRadius4, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contain, contentBox, cover, cursor, display, displayFlex, em, ex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, inlineBlock, int, justifyContent, lastChild, left, listStyle, margin, margin2, margin3, marginBottom, marginLeft, marginRight, marginTop, maxContent, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, paddingLeft, pct, pointer, position, property, pseudoElement, px, rem, row, solid, textDecoration, top, underline, url, width, zero)
 import Css.Global exposing (global, typeSelector)
-import Css.Media as Media exposing (only, screen, withMedia)
+import Css.Media as Media exposing (only, print, screen, withMedia)
 import Html.Styled exposing (Html, h1, text)
 import Html.Styled.Attributes exposing (id, tabindex)
 import Theme.FluidScale
@@ -68,6 +68,30 @@ withMediaDesktopUp =
     withMedia [ only screen [ Media.minWidth (px maxSmallDesktop) ] ]
 
 
+withMediaPrint : Maybe (List Style) -> Style
+withMediaPrint styles =
+    case styles of
+        Just s ->
+            withMedia [ only print [] ] <|
+                [ backgroundColor white
+                , color black
+                , border (px 0)
+                ]
+                    ++ s
+
+        Nothing ->
+            withMedia [ only print [] ]
+                [ backgroundColor white
+                , color black
+                , border (px 0)
+                ]
+
+
+hideFromPrint : Style
+hideFromPrint =
+    withMedia [ only print [] ] [ display none ]
+
+
 
 -- Colours
 
@@ -90,6 +114,11 @@ lightTeal =
 white : Color
 white =
     hex "ffffff"
+
+
+black : Color
+black =
+    hex "000000"
 
 
 
@@ -129,6 +158,7 @@ globalStyles =
         [ typeSelector "body"
             [ fontFamilies [ "Rubik", "sans-serif" ]
             , margin zero
+            , withMediaPrint Nothing
             ]
         , typeSelector "h1"
             [ fontFamilies [ "Adelle", "serif" ]
@@ -136,6 +166,7 @@ globalStyles =
             , margin3 (rem 0) auto (rem 1.5)
             , Theme.FluidScale.fontSizeExtraLarge
             , width (pct 100)
+            , withMediaPrint Nothing
             ]
         , typeSelector "h2"
             [ fontFamilies [ "Adelle", "serif" ]
@@ -143,18 +174,21 @@ globalStyles =
             , margin3 (rem 0) auto (rem 1.5)
             , Theme.FluidScale.fontSizeLarge
             , width (pct 100)
+            , withMediaPrint Nothing
             ]
         , typeSelector "h3"
             [ fontFamilies [ "Adelle", "serif" ]
             , color purple
             , margin3 (rem 0) auto (rem 1)
             , Theme.FluidScale.fontSizeMedium
+            , withMediaPrint Nothing
             ]
         , typeSelector "h4"
             [ fontFamilies [ "Adelle", "serif" ]
             , color purple
             , margin3 (rem 0) auto (rem 1)
             , Theme.FluidScale.fontSizeBase
+            , withMediaPrint Nothing
             ]
         , typeSelector "a"
             [ color purple
@@ -171,6 +205,15 @@ globalStyles =
                 , width (em 1.0)
                 , marginLeft (em 0.3)
                 ]
+            , withMediaPrint <|
+                Just
+                    [ textDecoration underline
+                    , pseudoElement "after"
+                        [ Css.property "content" """ " (" attr(href) ")" """
+                        , backgroundImage none
+                        , minWidth maxContent
+                        ]
+                    ]
             ]
         , typeSelector "b"
             []

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -202,8 +202,8 @@ globalStyles =
                 , width (em 1.0)
                 , marginLeft (em 0.3)
                 ]
-            , withMediaPrint <|
-                Just
+            , withMediaPrint
+                (Just
                     [ textDecoration underline
                     , pseudoElement "after"
                         [ Css.property "content" """ " (" attr(href) ")" """
@@ -211,6 +211,7 @@ globalStyles =
                         , minWidth (pct 100)
                         ]
                     ]
+                )
             ]
         , typeSelector "b"
             []

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,6 +1,6 @@
 module Theme.Global exposing (borderWrapper, centerContent, contentWrapper, featureImageStyle, globalStyles, hideFromPrint, lightTeal, listStyleNone, pageColumnBlockStyle, pageColumnStyle, primaryHeader, purple, roundedCornerStyle, screenReaderOnly, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, topTwoColumnsWrapperStyle, white, withMediaDesktopUp, withMediaMobileUp, withMediaPrint, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 
-import Css exposing (Color, Style, absolute, alignItems, auto, backgroundColor, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, border, border3, borderBottomRightRadius, borderRadius4, borderTopLeftRadius, borderTopRightRadius, boxSizing, center, color, column, contain, contentBox, cover, cursor, display, displayFlex, em, ex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, inlineBlock, int, justifyContent, lastChild, left, listStyle, margin, margin2, margin3, marginBottom, marginLeft, marginRight, marginTop, maxContent, maxWidth, minWidth, noRepeat, noWrap, none, overflow, padding, padding2, paddingLeft, pct, pointer, position, property, pseudoElement, px, rem, row, solid, textDecoration, top, underline, url, width, zero)
+import Css exposing (Color, Style, absolute, alignItems, auto, backgroundColor, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, border, border3, borderBottomRightRadius, borderRadius4, borderTopLeftRadius, borderTopRightRadius, boxSizing, breakWord, center, cm, color, column, contain, contentBox, cover, cursor, display, displayFlex, em, ex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, inherit, inlineBlock, int, justifyContent, lastChild, left, listStyle, margin, margin2, margin3, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minWidth, noRepeat, noWrap, none, overflow, overflowWrap, padding, padding2, paddingLeft, pct, pointer, position, property, pseudoElement, px, rem, row, solid, textDecoration, top, underline, url, width, zero)
 import Css.Global exposing (global, typeSelector)
 import Css.Media as Media exposing (only, print, screen, withMedia)
 import Html.Styled exposing (Html, h1, text)
@@ -68,23 +68,20 @@ withMediaDesktopUp =
     withMedia [ only screen [ Media.minWidth (px maxSmallDesktop) ] ]
 
 
+basePrintStyles : List Style
+basePrintStyles =
+    [ backgroundColor white
+    , color black
+    , border (px 0)
+    , overflowWrap breakWord
+    ]
+
+
 withMediaPrint : Maybe (List Style) -> Style
 withMediaPrint styles =
-    case styles of
-        Just s ->
-            withMedia [ only print [] ] <|
-                [ backgroundColor white
-                , color black
-                , border (px 0)
-                ]
-                    ++ s
-
-        Nothing ->
-            withMedia [ only print [] ]
-                [ backgroundColor white
-                , color black
-                , border (px 0)
-                ]
+    withMedia [ only print [] ] <|
+        basePrintStyles
+            ++ Maybe.withDefault [] styles
 
 
 hideFromPrint : Style
@@ -211,7 +208,7 @@ globalStyles =
                     , pseudoElement "after"
                         [ Css.property "content" """ " (" attr(href) ")" """
                         , backgroundImage none
-                        , minWidth maxContent
+                        , minWidth (pct 100)
                         ]
                     ]
             ]
@@ -234,6 +231,8 @@ globalStyles =
             , overflow hidden
             , width (pct 100)
             ]
+        , typeSelector "@page"
+            [ margin (cm 1.5) ]
         ]
 
 

--- a/src/Theme/HeaderTemplate.elm
+++ b/src/Theme/HeaderTemplate.elm
@@ -14,7 +14,7 @@ import Page.Shared.Data
 import Route exposing (Route(..))
 import Shared exposing (Model, Request(..))
 import Theme.FluidScale
-import Theme.Global exposing (borderWrapper, centerContent, purple, screenReaderOnly, teal, white, withMediaMobileUp)
+import Theme.Global exposing (borderWrapper, centerContent, hideFromPrint, purple, screenReaderOnly, teal, white, withMediaMobileUp, withMediaPrint)
 
 
 view : Model -> Html Msg
@@ -24,11 +24,11 @@ view model =
         t =
             translate model.language
     in
-    header [ css [ headerOuterStyle ] ]
+    header [ css [ headerOuterStyle, withMediaPrint Nothing ] ]
         [ div [ css [ centerContent ] ]
             [ div [ css [ headerContainerStyle ] ]
                 [ viewSiteTitle (t SiteTitle)
-                , div [ css [ searchButtonsContainerStyle ] ]
+                , div [ css [ searchButtonsContainerStyle, hideFromPrint ] ]
                     [ button [ css [ headerBtnStyle ], onClick LanguageChangeRequested ]
                         [ text (t ChangeLanguage) ]
                     , case model.page of

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -7,7 +7,7 @@ import Html.Styled.Attributes exposing (css)
 import Message exposing (Msg)
 import Shared exposing (Model)
 import Theme.FooterTemplate as FooterTemplate
-import Theme.Global exposing (borderWrapper, globalStyles, lightTeal)
+import Theme.Global exposing (borderWrapper, globalStyles, lightTeal, withMediaPrint)
 import Theme.HeaderTemplate as HeaderTemplate
 
 
@@ -18,7 +18,7 @@ view model content =
         , div
             [ css [ pageWrapperStyles ] ]
             [ HeaderTemplate.view model
-            , main_ [ css [ mainContainerStyles ] ]
+            , main_ [ css [ mainContainerStyles, withMediaPrint Nothing ] ]
                 [ content
                 ]
             , FooterTemplate.view model.language

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -85,3 +85,7 @@ app.ports.updateAnalyticsEvent.subscribe(function (gaEvent) {
     });
   }
 });
+
+app.ports.print.subscribe(function () {
+  window.print();
+});


### PR DESCRIPTION
Fixes #57 

## Description

- css for print media
    - hides many interactive elements
    - shows url for any links in body text
    - all black text on white background 
- adds a port to trigger opening print dialogue for page
- new keys added to copy spreadsheet

@geeksforsocialchange/developers
