### PR TITLE
Share your story box appears on guide page & story page

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -76,7 +76,7 @@ collections:
           i18n: true,
         }
       - {
-          label: "Call for story 1st sentance",
+          label: "Call for story 1st sentence",
           hint: "Make the call to action relevant to the content of the story e.g 'Have you started a community group?'",
           name: "customCall",
           widget: "string",

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -191,7 +191,7 @@ collections:
         required: false
         i18n: false
       - {
-          label: "Call for story 1st sentance",
+          label: "Call for story 1st sentence",
           hint: "Make the call to action relevant to the content of the story e.g 'Have you started a community group?'",
           name: "customCall",
           widget: "string",

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -75,6 +75,13 @@ collections:
           pattern: ["^.{50,160}$", "Must be between 50 and 160 characters"],
           i18n: true,
         }
+      - {
+          label: "Call for story 1st sentance",
+          hint: "Make the call to action relevant to the content of the story e.g 'Have you started a community group?'",
+          name: "customCall",
+          widget: "string",
+          i18n: true,
+        }
       - { label: "Body", name: "body", widget: "markdown", i18n: true }
   - name: "guides"
     label: "Guides"
@@ -183,6 +190,13 @@ collections:
         display_fields: ["title"]
         required: false
         i18n: false
+      - {
+          label: "Call for story 1st sentance",
+          hint: "Make the call to action relevant to the content of the story e.g 'Have you started a community group?'",
+          name: "customCall",
+          widget: "string",
+          i18n: true,
+        }
   - name: "pages"
     label: "Pages"
     folder: "content/pages"

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -12,6 +12,9 @@ enStrings key =
         GuidesMetaDescription ->
             "[cCc] Description for the guides search page"
 
+        CallForStoryP ->
+            " If you would like to submit a case study like this we would love to hear from your [cCc]"
+
         ---
         -- Header
         ---
@@ -136,8 +139,8 @@ enStrings key =
         CallForStoryHeading ->
             "Share your story!"
 
-        CallForStoryP ->
-            "[cCc] Have done something great for nature in your community? We would love to share your experience to help others, including any challenges you faced or hurdles you had to overcome."
+        HomeCallForStoryP ->
+            "[cCc] Have you done something great for nature in your community? What challenges or hurdles did you overcome?"
 
         CallForStoryLinkText ->
             "Send us your story"

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -42,6 +42,7 @@ type Key
     | GuideHighlightsSubtitle
     | StoryHighlightsSubtitle
     | CallForStoryHeading
+    | HomeCallForStoryP
     | CallForStoryP
     | CallForStoryLinkText
       --- Guide Page

--- a/src/Page/Guide/Data.elm
+++ b/src/Page/Guide/Data.elm
@@ -24,6 +24,7 @@ type alias Guide =
     , relatedStoryList : List String
     , relatedGuideList : List String
     , categorySlug : String
+    , customCall : Maybe String
     }
 
 
@@ -82,6 +83,8 @@ guideDictDecoder =
                 )
             |> Json.Decode.Extra.andMap
                 (Json.Decode.field "category" Json.Decode.string |> Json.Decode.Extra.withDefault "")
+            |> Json.Decode.Extra.andMap
+                (Json.Decode.maybe (Json.Decode.field "customCall" Json.Decode.string))
         )
 
 

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -39,7 +39,9 @@ view language guide allGuides allStories =
                   , viewPrintGuide language
                   , viewRelatedGuideTeasers language guide.relatedGuideList allGuides
                   ]
-                , [ viewRelatedStoryTeasers language guide.relatedStoryList allStories, Page.Shared.View.viewCallForStory language call ]
+                , [ viewRelatedStoryTeasers language guide.relatedStoryList allStories
+                  , Page.Shared.View.viewCallForStory language call
+                  ]
                 )
             ]
         ]

--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -19,6 +19,10 @@ import Theme.Markdown exposing (markdownToHtml)
 
 view : Language -> Page.Guide.Data.Guide -> List Page.Guide.Data.GuideListItem -> List Page.Story.Data.StoryTeaser -> Html Msg
 view language guide allGuides allStories =
+    let
+        call =
+            Maybe.withDefault (translate language HomeCallForStoryP) guide.customCall
+    in
     div []
         [ div [ css [ outerBorderStyle, withMediaPrint (Just [ marginBottom (rem 0) ]) ] ]
             [ div
@@ -35,7 +39,7 @@ view language guide allGuides allStories =
                   , viewPrintGuide language
                   , viewRelatedGuideTeasers language guide.relatedGuideList allGuides
                   ]
-                , [ viewRelatedStoryTeasers language guide.relatedStoryList allStories ]
+                , [ viewRelatedStoryTeasers language guide.relatedStoryList allStories, Page.Shared.View.viewCallForStory language call ]
                 )
             ]
         ]

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -8,6 +8,7 @@ import I18n.Translate exposing (Language, translate)
 import Message exposing (Msg)
 import Page.Guides.Data
 import Page.Guides.View
+import Page.Shared.View exposing (viewCallForStory)
 import Shared exposing (Model, shuffleList)
 import Theme.FluidScale
 import Theme.Global exposing (centerContent, contentWrapper, pageColumnBlockStyle, pageColumnStyle, primaryHeader, purple, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
@@ -49,7 +50,7 @@ view model =
                     , ExploreGuidesListPlaceholder
                     , ExploreGuidesListPlaceholder
                     ]
-                    ++ [ viewCallForStory model.language ]
+                    ++ [ viewCallForStory model.language (t HomeCallForStoryP) ]
                 )
             ]
         ]
@@ -58,20 +59,6 @@ view model =
 viewTextColumn : (Key -> String) -> List Key -> List (Html msg)
 viewTextColumn t paragraphs =
     List.map (\para -> p [ css [ pageColumnBlockStyle ] ] [ text (t para) ]) paragraphs
-
-
-viewCallForStory : Language -> Html Msg
-viewCallForStory language =
-    let
-        t : Key -> String
-        t =
-            translate language
-    in
-    div [ css [ callForStoryStyle, Theme.Global.roundedCornerStyle ] ]
-        [ h2 [ css [ callForStoryHeadingStyle ] ] [ text (t CallForStoryHeading) ]
-        , p [] [ text (t CallForStoryP) ]
-        , a [ href "submit story Route [cCc]", css [ callForStoryLinkStyle ] ] [ text (t CallForStoryLinkText) ]
-        ]
 
 
 teaserSubtitleStyle : Style
@@ -89,31 +76,4 @@ teaserColumnStyle =
         , property "gap" "1rem"
         , withMediaTabletPortraitUp [ flexDirection column ]
         , withMediaMobileUp [ flexDirection row ]
-        ]
-
-
-callForStoryStyle : Style
-callForStoryStyle =
-    batch
-        [ backgroundColor purple
-        , color white
-        , padding (rem 1)
-        , width (pct 100)
-        ]
-
-
-callForStoryHeadingStyle : Style
-callForStoryHeadingStyle =
-    color white
-
-
-callForStoryLinkStyle : Style
-callForStoryLinkStyle =
-    batch
-        [ backgroundImage (url "/images/arrow--white.svg")
-        , backgroundPosition right
-        , backgroundRepeat noRepeat
-        , color white
-        , fontWeight (int 500)
-        , paddingRight (rem 1.5)
         ]

--- a/src/Page/Shared/View.elm
+++ b/src/Page/Shared/View.elm
@@ -1,11 +1,13 @@
-module Page.Shared.View exposing (viewAudio, viewVideo)
+module Page.Shared.View exposing (viewAudio, viewCallForStory, viewVideo)
 
-import Css exposing (Style, absolute, batch, height, left, paddingBottom, pct, position, relative, top, width, zero)
-import Html.Styled exposing (Html, div, iframe, text)
-import Html.Styled.Attributes exposing (attribute, autoplay, css, src, title)
+import Css exposing (Style, absolute, backgroundColor, backgroundImage, backgroundPosition, backgroundRepeat, batch, color, fontWeight, height, int, left, noRepeat, padding, paddingBottom, paddingRight, pct, position, relative, rem, right, top, url, width, zero)
+import Html.Styled exposing (Html, a, div, h2, iframe, p, text)
+import Html.Styled.Attributes exposing (attribute, autoplay, css, href, src, title)
+import I18n.Keys exposing (Key(..))
+import I18n.Translate exposing (Language, translate)
 import Message exposing (Msg)
 import Page.Shared.Data
-import Theme.Global exposing (hideFromPrint)
+import Theme.Global exposing (hideFromPrint, purple, white)
 
 
 viewVideo : Page.Shared.Data.VideoMeta -> Html Msg
@@ -29,6 +31,47 @@ viewAudio _ =
         [ css [ embeddedVideoStyle, hideFromPrint ]
         ]
         [ text "[fFf] render audio player" ]
+
+
+viewCallForStory : Language -> String -> Html Msg
+viewCallForStory language customCall =
+    let
+        t : Key -> String
+        t =
+            translate language
+    in
+    div [ css [ callForStoryStyle, Theme.Global.roundedCornerStyle ] ]
+        [ h2 [ css [ callForStoryHeadingStyle ] ] [ text (t CallForStoryHeading) ]
+        , p [] [ text (customCall ++ t CallForStoryP) ]
+        , a [ href "submit story Route [cCc]", css [ callForStoryLinkStyle ] ] [ text (t CallForStoryLinkText) ]
+        ]
+
+
+callForStoryStyle : Style
+callForStoryStyle =
+    batch
+        [ backgroundColor purple
+        , color white
+        , padding (rem 1)
+        , width (pct 100)
+        ]
+
+
+callForStoryHeadingStyle : Style
+callForStoryHeadingStyle =
+    color white
+
+
+callForStoryLinkStyle : Style
+callForStoryLinkStyle =
+    batch
+        [ backgroundImage (url "/images/arrow--white.svg")
+        , backgroundPosition right
+        , backgroundRepeat noRepeat
+        , color white
+        , fontWeight (int 500)
+        , paddingRight (rem 1.5)
+        ]
 
 
 embeddedVideoStyle : Style

--- a/src/Page/Story/Data.elm
+++ b/src/Page/Story/Data.elm
@@ -19,6 +19,7 @@ type alias Story =
     , maybeGroupOrIndividual : Maybe String
     , images : List Image
     , fullTextMarkdown : String
+    , customCall : Maybe String
     }
 
 
@@ -59,6 +60,8 @@ storyDictDecoder =
                 (Json.Decode.field "images" (Json.Decode.list imageDecoder))
             |> Json.Decode.Extra.andMap
                 (Json.Decode.field "content" Json.Decode.string |> Json.Decode.Extra.withDefault "")
+            |> Json.Decode.Extra.andMap
+                (Json.Decode.maybe (Json.Decode.field "customCall" Json.Decode.string))
         )
 
 

--- a/src/Page/Story/View.elm
+++ b/src/Page/Story/View.elm
@@ -6,6 +6,7 @@ import Html.Styled.Attributes exposing (alt, css, src)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language, translate)
 import Message exposing (Msg)
+import Page.Shared.View
 import Page.Story.Data
 import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, pageColumnStyle, primaryHeader, topTwoColumnsWrapperStyle)
 import Theme.Markdown exposing (markdownToHtml)
@@ -17,6 +18,9 @@ view language story =
         t : Key -> String
         t =
             translate language
+
+        call =
+            Maybe.withDefault (t HomeCallForStoryP) story.customCall
     in
     div [ css [ centerContent ] ]
         [ primaryHeader [] story.title
@@ -47,6 +51,8 @@ view language story =
                     ]
                 , div [ css [ pageColumnStyle ] ]
                     (markdownToHtml story.fullTextMarkdown)
+                , div [ css [ pageColumnStyle ] ]
+                    [ Page.Shared.View.viewCallForStory language call ]
                 ]
             ]
         ]

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -384,7 +384,7 @@ columnWidthStyle : Style
 columnWidthStyle =
     batch
         [ withMediaTabletPortraitUp
-            [ minWidth (px (maxTabletPortrait / 3))
+            [ minWidth (px (maxTabletPortrait / 3.6))
             ]
         ]
 

--- a/tests/Guide.elm
+++ b/tests/Guide.elm
@@ -29,6 +29,7 @@ suite =
             , relatedStoryList = []
             , relatedGuideList = []
             , categorySlug = "admin-and-info"
+            , customCall = Nothing
             }
 
         guideFull : Guide
@@ -57,6 +58,7 @@ suite =
                 , "Another related guide"
                 ]
             , categorySlug = "admin-and-info"
+            , customCall = Just "First line of a call to submit story box"
             }
 
         allGuideList : List GuideListItem

--- a/tests/Story.elm
+++ b/tests/Story.elm
@@ -24,6 +24,7 @@ suite =
             , maybeLocation = Nothing
             , maybeGroupOrIndividual = Nothing
             , images = []
+            , customCall = Nothing
             }
 
         storyFull : Story
@@ -40,6 +41,7 @@ suite =
                   , maybeCredit = Just "credit"
                   }
                 ]
+            , customCall = Just "First line of a call to submit story box"
             }
 
         view : Story -> Html.Styled.Html Message.Msg


### PR DESCRIPTION
Fixes #336 

## Description

- new field added to guide/story records
- new widget added to the cms for each type
- falls back to homepage content if none supplied

these are the two entries with modified content for testing

guide - https://336-share-your-story-box.team-wilder-proto.pages.dev/guides/test-guide-with-all-content
story - https://336-share-your-story-box.team-wilder-proto.pages.dev/stories/test-story-with-minimal-fields

@geeksforsocialchange/developers
