### PR TITLE
Text copy update

### DIFF
--- a/src/I18n/Cy.elm
+++ b/src/I18n/Cy.elm
@@ -7,28 +7,161 @@ cyStrings : Key -> String
 cyStrings key =
     case key of
         SiteTitle ->
-            "[cCc] Hwb Natur Drws-nesaf"
+            "Hwb Natur Drws Nesaf"
 
+        GuidesMetaDescription ->
+            ""
+
+        ---
+        -- Header
+        ---
+        ChangeLanguage ->
+            "Newid i Gymraeg"
+
+        ---
+        -- 404 content
+        ---
         ResourceNotFoundTitle ->
-            "[cCc] Oops! CY"
+            ""
 
         ResourceNotFoundText ->
-            "[cCc] Looks like we've popped up on the wrong page CY"
+            ""
 
         ResourceNotFoundLinkText ->
-            "[cCc] Back to home page CY"
+            ""
 
         ResourceNotFoundLinkPath ->
             "/"
 
-        GuidesTitle ->
-            "[cCc] Guides CY"
+        ---
+        -- Footer
+        ---
+        FooterTitleColumnA ->
+            "Mwy o wybodaeth"
 
-        GuidesMetaDescription ->
-            "[cCc] Guides Description in Welsh"
+        FooterTitleColumnB ->
+            "Archwilio’r hwb yma"
 
-        GuidesTitleFiltered num query ->
-            num ++ " CY guides on '" ++ query ++ "' [cCc]"
+        FooterGuidesLinkText ->
+            "Archwilio ein canllawiau"
+
+        FooterGuidesLink ->
+            "/guides"
+
+        FooterTitleColumnC ->
+            "Cymryd rhan"
+
+        FooterVisitWebsiteText ->
+            "Mynd i wefan yr Ymddiriedolaethau Natur"
+
+        FooterVisitWebsiteLink ->
+            --[cCc]
+            "https://www.wildlifetrusts.org/"
+
+        FooterAboutText ->
+            "Mwy o wybodaeth am y prosiect yma"
+
+        FooterAboutLink ->
+            "/about"
+
+        FooterFindYourLocalTrustText ->
+            "Dod o hyd i’ch Ymddiriedolaeth leol"
+
+        FooterFindYourLocalTrustLink ->
+            --[cCc]
+            "https://www.wildlifetrusts.org/wildlife-trusts"
+
+        FooterPrivacyPolicyText ->
+            "Polisi preifatrwydd"
+
+        FooterPrivacyPolicyLink ->
+            "/privacy-policy"
+
+        FooterHowToUseThisSiteText ->
+            ""
+
+        FooterHowToUseThisSiteLink ->
+            "/how-to-use-this-site"
+
+        FooterSiteLogo ->
+            "Natur Drws Nesaf"
+
+        FooterCharityInfo ->
+            "Mae Hwb Natur Drws Nesaf yn brosiect gan yr Ymddiriedolaethau Natur ac mae wedi’i gyllido gan Gronfa Dreftadaeth y Loteri Genedlaethol"
+
+        RegisteredCharityNumber ->
+            "Rhif elusen gofrestredig 20723"
+
+        ---
+        -- Cookie banner
+        ---
+        CookieBannerH2 ->
+            "Ydych chi’n iawn i fwrw ymlaen gyda'r holl gwcis a data?"
+
+        CookieBannerP ->
+            """
+            Mae ein gwefan ni’n defnyddio cwcis a data i wneud yn siŵr eich bod yn cael y profiad gorau ac i'n helpu ni i godi arian yn effeithlon i achub bywyd gwyllt. Mae rhai cwcis yn hanfodol i wneud i'n gwefan ni weithio.
+            """
+
+        CookieAcceptButtonText ->
+            "Iawn, rydw i’n deall"
+
+        CookieDeclineButtonText ->
+            "Dim Diolch"
+
+        CookieSettingsButtonText ->
+            "Gosodiadau cwcis"
+
+        ---
+        -- Index page
+        ---
+        HomeTitle ->
+            "Croeso i Hwb Natur Drws Nesaf"
+
+        WelcomeP1 ->
+            ""
+
+        WelcomeP2 ->
+            ""
+
+        WelcomeP3 ->
+            ""
+
+        GuideHighlightsSubtitle ->
+            "Uchafbwyntiau’r canllawiau"
+
+        StoryHighlightsSubtitle ->
+            "Uchafbwyntiau'r straeon"
+
+        CallForStoryHeading ->
+            "Rhannwch eich stori!"
+
+        CallForStoryP ->
+            ""
+
+        CallForStoryLinkText ->
+            ""
+
+        ---
+        -- Guide Page
+        ---
+        RelatedGuidesHeading ->
+            "Canllawiau cysylltiedig"
+
+        RelatedStoriesHeading ->
+            "Straeon cysylltiedig"
+
+        GuidePrintHeader ->
+            ""
+
+        GuideVideoHeader ->
+            ""
+
+        GuideAudioHeader ->
+            ""
+
+        GuideTextHeader ->
+            ""
 
         GuidePrintHeaderIconLink ->
             "/images/icons/NextDoorNature_icons-print.svg"
@@ -42,61 +175,53 @@ cyStrings key =
         GuideTextHeaderIconLink ->
             "/images/icons/NextDoorNature_icons-text.svg"
 
-        ChangeLanguage ->
-            "[cCc] Switch to English"
+        GuideButtonText ->
+            ""
 
-        FooterTitleColumnA ->
-            "[cCc] 🔎🔎🔎🔎🔎🔎"
+        GuideParagraphText ->
+            ""
 
-        FooterTitleColumnB ->
-            "[cCc] 📚📚📚📚📚📚📚"
+        ---
+        -- Guides Page
+        ---
+        GuidesTitle ->
+            "Canllawiau"
 
-        FooterTitleColumnC ->
-            "[cCc] 🦾🦾🦾🦾🦾🦾"
-
-        FooterHowToUseThisSiteText ->
-            "[cCc] How to use this site CY"
-
-        FooterHowToUseThisSiteLink ->
-            "/how-to-use-this-site"
-
-        FooterVisitWebsiteText ->
-            "[cCc] 🌳🌲🌲🌳🌳🌲🐿️🌳🌲🌳🌳"
-
-        FooterVisitWebsiteLink ->
-            --[cCc]
-            "https://www.wildlifetrusts.org/"
-
-        FooterFindYourLocalTrustText ->
-            "[cCc] 🌳🌲🌲🌳🌳🌲🐿️🌳🌲🌳🌳"
-
-        FooterFindYourLocalTrustLink ->
-            --[cCc]
-            "https://www.wildlifetrusts.org/wildlife-trusts"
-
-        FooterSiteLogo ->
-            "[cCc] Natur Drws-nesaf"
+        GuidesTitleFiltered num query ->
+            num ++ " guides on '" ++ query ++ "' [cCc]"
 
         SearchPlaceholder ->
-            "[cCc] Cy label"
+            "Chwilio’r hwb yma"
+
+        ExploreGuidesListPlaceholder ->
+            "Archwilio’r canllawiau yn ôl pwnc"
+
+        ---
+        -- Story Page
+        ---
+        WhereSubHeading ->
+            "Ble"
+
+        WhoSubHeading ->
+            "Pwy"
 
         ---
         -- Category things
         ---
         CategoryAdminAndInfoName ->
-            "Grwpiau Cymunedol - Gweinyddol a Gwybodaeth"
+            ""
 
         CategoryPublicityEventsName ->
-            "Cyfryngau, Cyhoeddusrwydd a Digwyddiadau"
+            ""
 
         CategoryWorkingWithPeopleName ->
-            "Gweithio gyda Phobl"
+            ""
 
         CategoryWorkingWithAuthoritiesName ->
-            "Gweithio gyda'r Awdurdodau"
+            ""
 
         InCategory ->
-            "[cCc] In category CY"
+            ""
 
         _ ->
             "[cCc] [fFf] to reminder to add all Welsh Keys back"

--- a/src/I18n/Cy.elm
+++ b/src/I18n/Cy.elm
@@ -10,7 +10,7 @@ cyStrings key =
             "Hwb Natur Drws Nesaf"
 
         GuidesMetaDescription ->
-            ""
+            "[cCc]"
 
         ---
         -- Header
@@ -22,13 +22,13 @@ cyStrings key =
         -- 404 content
         ---
         ResourceNotFoundTitle ->
-            ""
+            "[cCc]"
 
         ResourceNotFoundText ->
-            ""
+            "[cCc]"
 
         ResourceNotFoundLinkText ->
-            ""
+            "[cCc]"
 
         ResourceNotFoundLinkPath ->
             "/"
@@ -78,7 +78,7 @@ cyStrings key =
             "/privacy-policy"
 
         FooterHowToUseThisSiteText ->
-            ""
+            "[cCc]"
 
         FooterHowToUseThisSiteLink ->
             "/how-to-use-this-site"
@@ -119,13 +119,13 @@ cyStrings key =
             "Croeso i Hwb Natur Drws Nesaf"
 
         WelcomeP1 ->
-            ""
+            "[cCc]"
 
         WelcomeP2 ->
-            ""
+            "[cCc]"
 
         WelcomeP3 ->
-            ""
+            "[cCc]"
 
         GuideHighlightsSubtitle ->
             "Uchafbwyntiau’r canllawiau"
@@ -137,10 +137,10 @@ cyStrings key =
             "Rhannwch eich stori!"
 
         CallForStoryP ->
-            ""
+            "[cCc]"
 
         CallForStoryLinkText ->
-            ""
+            "[cCc]"
 
         ---
         -- Guide Page
@@ -152,16 +152,16 @@ cyStrings key =
             "Straeon cysylltiedig"
 
         GuidePrintHeader ->
-            ""
+            "[cCc]"
 
         GuideVideoHeader ->
-            ""
+            "[cCc]"
 
         GuideAudioHeader ->
-            ""
+            "[cCc]"
 
         GuideTextHeader ->
-            ""
+            "[cCc]"
 
         GuidePrintHeaderIconLink ->
             "/images/icons/NextDoorNature_icons-print.svg"
@@ -176,10 +176,10 @@ cyStrings key =
             "/images/icons/NextDoorNature_icons-text.svg"
 
         GuideButtonText ->
-            ""
+            "[cCc]"
 
         GuideParagraphText ->
-            ""
+            "[cCc]"
 
         ---
         -- Guides Page
@@ -209,19 +209,16 @@ cyStrings key =
         -- Category things
         ---
         CategoryAdminAndInfoName ->
-            ""
+            "[cCc]"
 
         CategoryPublicityEventsName ->
-            ""
+            "[cCc]"
 
         CategoryWorkingWithPeopleName ->
-            ""
+            "[cCc]"
 
         CategoryWorkingWithAuthoritiesName ->
-            ""
+            "[cCc]"
 
         InCategory ->
-            ""
-
-        _ ->
-            "[cCc] [fFf] to reminder to add all Welsh Keys back"
+            "[cCc]"

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -22,10 +22,10 @@ enStrings key =
         -- 404 content
         ---
         ResourceNotFoundTitle ->
-            "[cCc] Oops!"
+            "Oops!"
 
         ResourceNotFoundText ->
-            "[cCc] Looks like we've popped up on the wrong page"
+            "Looks like we've popped up on the wrong page!"
 
         ResourceNotFoundLinkText ->
             "[cCc] Back to home page"
@@ -78,7 +78,7 @@ enStrings key =
             "/privacy-policy"
 
         FooterHowToUseThisSiteText ->
-            "[cCc] How to use this site"
+            "How to use this site"
 
         FooterHowToUseThisSiteLink ->
             "/how-to-use-this-site"
@@ -134,7 +134,7 @@ enStrings key =
             "Story highlights"
 
         CallForStoryHeading ->
-            "Share your story!"
+            "Share your story"
 
         CallForStoryP ->
             "[cCc] Have done something great for nature in your community? We would love to share your experience to help others, including any challenges you faced or hurdles you had to overcome."
@@ -191,10 +191,10 @@ enStrings key =
             num ++ " guides on '" ++ query ++ "' [cCc]"
 
         SearchPlaceholder ->
-            "Search the hub"
+            "Search this hub"
 
         ExploreGuidesListPlaceholder ->
-            "[cCc] Explore guides by theme"
+            "Explore guides by topic"
 
         ---
         -- Story Page


### PR DESCRIPTION
Fixes #400

## Description

- Updated English translations
- Swept through Welsh, adding as many key/text tuples as I could

## Missing Welsh values
- GuidesMetaDescription
- ResourceNotFoundTitle
- ResourceNotFoundText
- ResourceNotFoundLinkText
- FooterHowToUseThisSiteText
- WelcomeP1
- WelcomeP2
- WelcomeP3
- CallForStoryP
- CallForStoryLinkText
- GuidePrintHeader
- GuideVideoHeader
- GuideAudioHeader
- GuideTextHeader
- GuideButtonText
- GuideParagraphText
- CategoryAdminAndInfoName
- CategoryPublicityEventsName
- CategoryWorkingWithPeopleName
- CategoryWorkingWithAuthoritiesName
- InCategory

@geeksforsocialchange/developers
