### PR TITLE
share story homepage position (and a link bug fix)

### DIFF
--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -43,13 +43,12 @@ view model =
                             |> List.take 2
                             |> Page.Guides.View.viewTeaserList False Page.Guides.View.homePageLayoutStyle
                         ]
+                    , viewCallForStory model.language
                     ]
                 ]
             , div [ css [ pageColumnStyle ] ]
                 (h2 [] [ text (t ExploreGuidesListHeading) ]
-                    :: (viewGuidesByCategory model.language (Page.Guide.Data.allGuidesSlugTitleList model.content.guides)
-                            ++ [ viewCallForStory model.language ]
-                       )
+                    :: viewGuidesByCategory model.language (Page.Guide.Data.allGuidesSlugTitleList model.content.guides)
                 )
             ]
         ]

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -113,7 +113,7 @@ viewCallForStory language =
     div [ css [ callForStoryStyle, Theme.Global.roundedCornerStyle ] ]
         [ h2 [ css [ callForStoryHeadingStyle ] ] [ text (t CallForStoryHeading) ]
         , p [] [ text (t CallForStoryP) ]
-        , a [ href "submit story Route [cCc]", css [ callForStoryLinkStyle ] ] [ text (t CallForStoryLinkText) ]
+        , a [ href (Route.toString Route.SubmitStory), css [ callForStoryLinkStyle ] ] [ text (t CallForStoryLinkText) ]
         ]
 
 

--- a/src/Page/Shared/View.elm
+++ b/src/Page/Shared/View.elm
@@ -7,6 +7,7 @@ import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language, translate)
 import Message exposing (Msg)
 import Page.Shared.Data exposing (VideoMeta)
+import Route exposing (Route(..))
 import Theme.Global exposing (hideFromPrint, purple, white)
 
 
@@ -50,7 +51,7 @@ viewCallForStory language customCall =
     div [ css [ callForStoryStyle, Theme.Global.roundedCornerStyle ] ]
         [ h2 [ css [ callForStoryHeadingStyle ] ] [ text (t CallForStoryHeading) ]
         , p [] [ text (customCall ++ t CallForStoryP) ]
-        , a [ href "submit story Route [cCc]", css [ callForStoryLinkStyle ] ] [ text (t CallForStoryLinkText) ]
+        , a [ href (Route.toString SubmitStory), css [ callForStoryLinkStyle ] ] [ text (t CallForStoryLinkText) ]
         ]
 
 


### PR DESCRIPTION
Fixes #433

## Description

- move share story box to middle column on homepgae
- make share story box link to share story page!

@geeksforsocialchange/developers
