### PR TITLE
move left column content on homepage into CMS

### DIFF
--- a/content/pages/cy/index.md
+++ b/content/pages/cy/index.md
@@ -1,0 +1,16 @@
+---
+title: Croeso i Hwb Natur Drws Nesaf
+---
+## This website will help you to help nature.
+
+Please explore our website. You can choose Welsh by clicking the button at the top. If you want to get in touch, please email us on [nextdoornature@wildlifetrust.org](mailto:nextdoornature@wildlifetrust.org). We’d love to hear from you!
+
+## Here, you will find GUIDES and STORIES. Guides are full of simple, easy-to-understand information in words and videos to help you to take action for nature.
+
+Nextdoor Nature is a project from The Wildlife Trusts. We’re working with communities to bring people together and give everyone the power to help nature flourish – everywhere.
+
+## Stories are where you can read all about what other people are doing where they live and work. They are full of ideas to show you how everyday communities can help nature and wildlife all over the UK. And you can share your story here too!
+
+Thanks to £5million funding from The National Lottery Heritage Fund, Nextdoor Nature provides you with the advice and support you need to help nature on your doorstep, and leave a lasting natural legacy to mark The Queen’s Platinum Jubilee.
+
+

--- a/content/pages/en/index.md
+++ b/content/pages/en/index.md
@@ -1,0 +1,17 @@
+---
+title: Welcome to the Nextdoor Nature Hub
+---
+
+## This website will help you to help nature.
+
+Please explore our website. You can choose Welsh by clicking the button at the top. If you want to get in touch, please email us on [nextdoornature@wildlifetrust.org](mailto:nextdoornature@wildlifetrust.org). We’d love to hear from you!
+
+## Here, you will find GUIDES and STORIES. Guides are full of simple, easy-to-understand information in words and videos to help you to take action for nature.
+
+Nextdoor Nature is a project from The Wildlife Trusts. We’re working with communities to bring people together and give everyone the power to help nature flourish – everywhere.
+
+## Stories are where you can read all about what other people are doing where they live and work. They are full of ideas to show you how everyday communities can help nature and wildlife all over the UK. And you can share your story here too!
+
+Thanks to £5million funding from The National Lottery Heritage Fund, Nextdoor Nature provides you with the advice and support you need to help nature on your doorstep, and leave a lasting natural legacy to mark The Queen’s Platinum Jubilee.
+
+

--- a/content/pages/en/index.md
+++ b/content/pages/en/index.md
@@ -4,13 +4,14 @@ title: Welcome to the Nextdoor Nature Hub
 
 ## This website will help you to help nature.
 
+
+Here, you will find *guides* and *stories*. Guides are full of simple, easy-to-understand information in words and videos to help you to take action for nature.
+
+Stories are where you can read all about what other people are doing where they live and work. They are full of ideas to show you how everyday communities can help nature and wildlife all over the UK. And you can share your story here too!
+
 Please explore our website. You can choose Welsh by clicking the button at the top. If you want to get in touch, please email us on [nextdoornature@wildlifetrust.org](mailto:nextdoornature@wildlifetrust.org). We’d love to hear from you!
 
-## Here, you will find GUIDES and STORIES. Guides are full of simple, easy-to-understand information in words and videos to help you to take action for nature.
-
 Nextdoor Nature is a project from The Wildlife Trusts. We’re working with communities to bring people together and give everyone the power to help nature flourish – everywhere.
-
-## Stories are where you can read all about what other people are doing where they live and work. They are full of ideas to show you how everyday communities can help nature and wildlife all over the UK. And you can share your story here too!
 
 Thanks to £5million funding from The National Lottery Heritage Fund, Nextdoor Nature provides you with the advice and support you need to help nature on your doorstep, and leave a lasting natural legacy to mark The Queen’s Platinum Jubilee.
 

--- a/src/I18n/Cy.elm
+++ b/src/I18n/Cy.elm
@@ -116,16 +116,7 @@ cyStrings key =
         ---
         -- Index page
         ---
-        HomeTitle ->
-            "Croeso i Hwb Natur Drws Nesaf"
-
         WelcomeP1 ->
-            "[cCc]"
-
-        WelcomeP2 ->
-            "[cCc]"
-
-        WelcomeP3 ->
             "[cCc]"
 
         GuideHighlightsSubtitle ->

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -123,17 +123,8 @@ enStrings key =
         ---
         -- Index page
         ---
-        HomeTitle ->
-            "Welcome to the Nextdoor Nature Hub"
-
         WelcomeP1 ->
             "Nextdoor Nature is bringing communities together to help nature flourish where you live and work!"
-
-        WelcomeP2 ->
-            "Thanks to £5million funding from The National Lottery Heritage Fund, Nextdoor Nature provides you with the advice and support you need to help nature on your doorstep, and leave a lasting natural legacy to mark The Queen’s Platinum Jubilee."
-
-        WelcomeP3 ->
-            "The guides on this Hub give you simple, straightforward information so you can take action for nation. And the stories are where you can find inspiration - and share your own experiences!"
 
         GuideHighlightsSubtitle ->
             "Guide highlights"

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -37,10 +37,7 @@ type Key
     | CookieDeclineButtonText
     | CookieSettingsButtonText
       --- Index Page
-    | HomeTitle
     | WelcomeP1
-    | WelcomeP2
-    | WelcomeP3
     | GuideHighlightsSubtitle
     | StoryHighlightsSubtitle
     | CallForStoryHeading

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -262,7 +262,18 @@ view : Model -> Html Msg
 view model =
     case model.page of
         Index ->
-            Theme.PageTemplate.view model (Page.Index.view model)
+            let
+                maybePage : Maybe Page.Data.Page
+                maybePage =
+                    Page.Data.pageFromSlug model.language model.content.pages "index"
+            in
+            Theme.PageTemplate.view model <|
+                case maybePage of
+                    Just page ->
+                        Page.Index.view model page
+
+                    Nothing ->
+                        resourceNotFound model.language
 
         Story slug ->
             let

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -6,28 +6,30 @@ import Html.Styled.Attributes exposing (css, href)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language, translate)
 import Message exposing (Msg)
+import Page.Data
 import Page.Guide.Data
 import Page.Guides.Data
 import Page.Guides.View
 import Route
 import Shared exposing (Model, shuffleList)
 import Theme.FluidScale
-import Theme.Global exposing (centerContent, contentWrapper, listStyleNone, pageColumnBlockStyle, pageColumnStyle, primaryHeader, purple, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
+import Theme.Global exposing (centerContent, contentWrapper, listStyleNone, pageColumnStyle, primaryHeader, purple, topTwoColumnsWrapperStyle, white, withMediaMobileUp, withMediaTabletPortraitUp)
+import Theme.Markdown exposing (markdownToHtml)
 
 
-view : Model -> Html Msg
-view model =
+view : Model -> Page.Data.Page -> Html Msg
+view model page =
     let
         t : Key -> String
         t =
             translate model.language
     in
     div [ css [ centerContent ] ]
-        [ primaryHeader [] (t HomeTitle)
+        [ primaryHeader [] page.title
         , div [ css [ contentWrapper ] ]
             [ div [ css [ topTwoColumnsWrapperStyle ] ]
                 [ div [ css [ pageColumnStyle ] ]
-                    (viewTextColumn t [ WelcomeP1, WelcomeP2, WelcomeP3 ])
+                    (markdownToHtml page.fullTextMarkdown)
                 , div [ css [ teaserColumnStyle ] ]
                     [ div []
                         [ h2 [ css [ teaserSubtitleStyle ] ] [ text (t GuideHighlightsSubtitle) ]
@@ -53,11 +55,6 @@ view model =
                 )
             ]
         ]
-
-
-viewTextColumn : (Key -> String) -> List Key -> List (Html msg)
-viewTextColumn t paragraphs =
-    List.map (\para -> p [ css [ pageColumnBlockStyle ] ] [ text (t para) ]) paragraphs
 
 
 viewGuidesByCategory : Language -> List Page.Guide.Data.GuideListItem -> List (Html msg)


### PR DESCRIPTION
Fixes #389

## Description

- create markdown pages for the left column and title of the homepage
- added content requested by Autumn

## Questions/notes

- I'm not sure this content is advisable in practice. I did my best to interpret the comment with different options in English and Welsh but that will be accessible in the CMS and can be changed by Autumn later.

@geeksforsocialchange/developers
