### PR TITLE
275 accessibility cleanup

### DIFF
--- a/src/I18n/Cy.elm
+++ b/src/I18n/Cy.elm
@@ -90,6 +90,15 @@ cyStrings key =
         RegisteredCharityNumber ->
             "Rhif elusen gofrestredig 207238"
 
+        HerritageFundLogoAlt ->
+            ""
+
+        PLatiJubesLogoAlt ->
+            ""
+
+        WildLifeTrustLogoAlt ->
+            ""
+
         ---
         -- Cookie banner
         ---

--- a/src/I18n/Cy.elm
+++ b/src/I18n/Cy.elm
@@ -90,10 +90,10 @@ cyStrings key =
         RegisteredCharityNumber ->
             "Rhif elusen gofrestredig 207238"
 
-        HerritageFundLogoAlt ->
+        HeritageFundLogoAlt ->
             ""
 
-        PLatiJubesLogoAlt ->
+        PlatiJubesLogoAlt ->
             ""
 
         WildLifeTrustLogoAlt ->

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -85,6 +85,15 @@ enStrings key =
             --[cCc]
             "/share-story"
 
+        HerritageFundLogoAlt ->
+            "Logo for the national lottery heritage fund"
+
+        PLatiJubesLogoAlt ->
+            "Logo for the queens platinum jubilee 2022"
+
+        WildLifeTrustLogoAlt ->
+            "Logo for the wildlife trust"
+
         FooterPrivacyPolicyText ->
             "Privacy policy"
 

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -85,10 +85,10 @@ enStrings key =
             --[cCc]
             "/share-story"
 
-        HerritageFundLogoAlt ->
+        HeritageFundLogoAlt ->
             "Logo for the national lottery heritage fund"
 
-        PLatiJubesLogoAlt ->
+        PlatiJubesLogoAlt ->
             "Logo for the queens platinum jubilee 2022"
 
         WildLifeTrustLogoAlt ->

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -32,6 +32,9 @@ type Key
     | FooterSiteLogo
     | FooterCharityInfo
     | RegisteredCharityNumber
+    | HerritageFundLogoAlt
+    | PLatiJubesLogoAlt
+    | WildLifeTrustLogoAlt
       --- Cookie banner
     | CookieBannerH2
     | CookieBannerP

--- a/src/I18n/Keys.elm
+++ b/src/I18n/Keys.elm
@@ -32,8 +32,8 @@ type Key
     | FooterSiteLogo
     | FooterCharityInfo
     | RegisteredCharityNumber
-    | HerritageFundLogoAlt
-    | PLatiJubesLogoAlt
+    | HeritageFundLogoAlt
+    | PlatiJubesLogoAlt
     | WildLifeTrustLogoAlt
       --- Cookie banner
     | CookieBannerH2

--- a/src/Page/Story/View.elm
+++ b/src/Page/Story/View.elm
@@ -1,7 +1,7 @@
 module Page.Story.View exposing (view)
 
 import Css exposing (Style, batch, fontStyle, italic, margin3, paddingBottom, pct, rem, width)
-import Html.Styled exposing (Html, blockquote, div, h3, img, p, text)
+import Html.Styled exposing (Html, blockquote, div, h2, img, p, text)
 import Html.Styled.Attributes exposing (alt, css, src)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language, translate)
@@ -33,7 +33,7 @@ view language story =
                         [ case story.maybeGroupOrIndividual of
                             Just groupOrIndividual ->
                                 div []
-                                    [ h3 [] [ text (t WhoSubHeading) ]
+                                    [ h2 [ css [ Theme.FluidScale.fontSizeMedium ] ] [ text (t WhoSubHeading) ]
                                     , p [] [ text groupOrIndividual ]
                                     ]
 
@@ -42,7 +42,7 @@ view language story =
                         , case story.maybeLocation of
                             Just location ->
                                 div []
-                                    [ h3 [] [ text (t WhereSubHeading) ]
+                                    [ h2 [ css [ Theme.FluidScale.fontSizeMedium ] ] [ text (t WhereSubHeading) ]
                                     , p [] [ text location ]
                                     ]
 

--- a/src/Theme/FooterTemplate.elm
+++ b/src/Theme/FooterTemplate.elm
@@ -3,7 +3,7 @@ module Theme.FooterTemplate exposing (view)
 import Css exposing (Style, alignItems, alignSelf, auto, backgroundColor, batch, border3, borderLeft3, borderTop, center, color, column, cursor, default, displayFlex, em, firstChild, fitContent, flexDirection, flexEnd, flexGrow, flexShrink, flexStart, flexWrap, fontFamilies, fontSize, height, int, justifyContent, lastChild, margin, margin2, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minHeight, minWidth, nthChild, padding, padding2, paddingBottom, px, rem, row, solid, spaceBetween, textDecoration, underline, unset, width, wrap)
 import Css.Media as Media exposing (only, screen, withMedia)
 import Html.Styled exposing (Html, a, div, footer, h3, img, li, nav, text, ul)
-import Html.Styled.Attributes exposing (css, href, src)
+import Html.Styled.Attributes exposing (alt, css, href, src)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language(..), translate)
 import Route exposing (Route)
@@ -34,9 +34,9 @@ view language route =
                     , div [ css [ marginTop (rem 0.5) ] ] [ text (t RegisteredCharityNumber) ]
                     ]
                 , div [ css [ logosContainerStyle ] ]
-                    [ img [ css [ logoStyle ], src (translatedLogoPath language "logo-heritage-fund") ] []
-                    , img [ css [ logoStyle ], src (translatedLogoPath language "logo-queens-platinum-jubilee") ] []
-                    , img [ css [ logoStyle ], src (translatedLogoPath language "logo-wildlife-trusts") ] []
+                    [ img [ css [ logoStyle ], src (translatedLogoPath language "logo-heritage-fund"), alt (t HerritageFundLogoAlt) ] []
+                    , img [ css [ logoStyle ], src (translatedLogoPath language "logo-queens-platinum-jubilee"), alt (t PLatiJubesLogoAlt) ] []
+                    , img [ css [ logoStyle ], src (translatedLogoPath language "logo-wildlife-trusts"), alt (t WildLifeTrustLogoAlt) ] []
                     , div [ css [ nextdoorNatureTextStyle, logoStyle ] ] [ text (t FooterSiteLogo) ]
                     ]
                 ]


### PR DESCRIPTION
work towards  #275 

## Description

wave recommendations

- [x] no alt text on icon images - add, or maybe better to hide from screenreaders? (the span containing the icon is aria-hidden already)
- [x] add alt text to footer logos
- [x] skipped heading level on stories - goes straight from h1 to h3 - who & where should be h2 if poss


@geeksforsocialchange/developers
