### PR TITLE
reverse translation so a welsh speaker on the english site is prompted

### DIFF
--- a/src/I18n/Cy.elm
+++ b/src/I18n/Cy.elm
@@ -13,7 +13,7 @@ cyStrings key =
         -- Header
         ---
         ChangeLanguage ->
-            "Newid i Saesneg"
+            "Switch to English"
 
         ---
         -- 404 content

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -19,7 +19,7 @@ enStrings key =
         -- Header
         ---
         ChangeLanguage ->
-            "Switch to Welsh"
+            "Newid i'r Gymraeg"
 
         ---
         -- 404 content


### PR DESCRIPTION
reverse translation so a welsh speaker on the english site is prompted to switch to welsh in their own language, and visa versa for english

Fixes #464 

## Description


- [x] `Newid i'r Saesneg` becomes `Switch to English`
- [x] `Switch to Welsh` becomes `Newid i'r Gymraeg`
- [x] copy added to spreadsheet so it can be signed off by Autumn

@geeksforsocialchange/developers
