### PR TITLE
Improve styling of guide headers

### DIFF
--- a/src/Page/Guide/View.elm
+++ b/src/Page/Guide/View.elm
@@ -1,6 +1,6 @@
 port module Page.Guide.View exposing (print, view)
 
-import Css exposing (Style, alignItems, auto, backgroundColor, batch, border, borderBottom3, center, color, column, display, displayFlex, em, flexDirection, flexStart, flexWrap, fontFamilies, hover, inlineBlock, justifyContent, listStyle, margin2, marginBottom, marginRight, marginTop, maxWidth, none, padding, paddingLeft, paddingRight, pct, px, rem, solid, textDecoration3, underline, width, wrap, zero)
+import Css exposing (Style, alignItems, auto, backgroundColor, batch, border, borderBottom3, center, color, column, display, displayFlex, em, flexBasis, flexDirection, flexEnd, flexStart, flexWrap, fontFamilies, fontWeight, hover, inlineBlock, int, justifyContent, listStyle, margin2, marginBottom, marginRight, marginTop, maxWidth, none, padding, paddingLeft, paddingRight, pct, property, px, rem, solid, textDecoration3, underline, unset, width, wrap, zero)
 import Html.Styled exposing (Html, a, button, div, h2, img, li, p, span, text, ul)
 import Html.Styled.Attributes exposing (alt, attribute, css, href, src)
 import Html.Styled.Events exposing (onClick)
@@ -13,7 +13,8 @@ import Page.Shared.Data
 import Page.Shared.View
 import Page.Story.Data
 import Route exposing (Route(..))
-import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, hideFromPrint, lightPurple, lightTeal, pageColumnStyle, primaryHeader, purple, teal, teaserImageStyle, topTwoColumnsWrapperStyle, withMediaPrint)
+import Theme.FluidScale
+import Theme.Global exposing (centerContent, contentWrapper, featureImageStyle, hideFromPrint, lightPurple, lightTeal, pageColumnStyle, primaryHeader, purple, simpleThreeColumnFlexChildStyle, simpleThreeColumnFlexStyle, teal, teaserImageStyle, topTwoColumnsWrapperStyle, withMediaPrint, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.Markdown exposing (markdownToHtml)
 
 
@@ -59,8 +60,8 @@ viewGuideHeader guide =
         [ div
             [ css [ headerContentStyle ] ]
             [ primaryHeader [ css [ guideTitleStyle ] ] guide.title
-            , viewRow
-                ( [ p [] [ text guide.summary ] ]
+            , viewHeaderRow
+                [ [ h2 [ css [ headerRowSubtitleStyle ] ] [ text guide.summary ] ]
                 , [ img [ css [ hideFromPrint, featureImageStyle ], src image.src, alt image.alt ] [] ]
                 , [ case image.maybeCredit of
                         Just aCredit ->
@@ -69,7 +70,7 @@ viewGuideHeader guide =
                         Nothing ->
                             text ""
                   ]
-                )
+                ]
             ]
         ]
 
@@ -97,6 +98,36 @@ viewRow ( content1, content2, content3 ) =
             , div [ css [ pageColumnStyle ] ] content2
             ]
         , div [ css [ pageColumnStyle ] ] content3
+        ]
+
+
+viewHeaderRow : List (List (Html Msg)) -> Html Msg
+viewHeaderRow contents =
+    div [ css [ simpleThreeColumnFlexStyle, headerRowMarginStyle ] ]
+        (List.map
+            (\content -> div [ css [ simpleThreeColumnFlexChildStyle ] ] content)
+            contents
+        )
+
+
+headerRowMarginStyle : Style
+headerRowMarginStyle =
+    batch
+        [ margin2 (rem 1) (rem 0)
+        , property "gap" "1rem 2rem"
+        , withMediaTabletLandscapeUp
+            [ margin2 (rem 2) (rem 0)
+            , property "gap" "3rem"
+            ]
+        ]
+
+
+headerRowSubtitleStyle : Style
+headerRowSubtitleStyle =
+    batch
+        [ color unset
+        , fontWeight (int 300)
+        , Theme.FluidScale.fontSizeMedium
         ]
 
 

--- a/src/Page/SubmitStory/View.elm
+++ b/src/Page/SubmitStory/View.elm
@@ -1,6 +1,6 @@
 module Page.SubmitStory.View exposing (view)
 
-import Css exposing (Style, batch, border, displayFlex, flexGrow, flexShrink, flexWrap, height, hidden, int, margin, margin2, overflow, pct, property, rem, width, wrap)
+import Css exposing (Style, batch, border, height, hidden, margin2, overflow, pct, property, rem, width)
 import Html.Styled exposing (Html, div, h2, iframe, img, text)
 import Html.Styled.Attributes as Attr exposing (css)
 import I18n.Keys exposing (Key(..))
@@ -8,7 +8,7 @@ import I18n.Translate exposing (translate)
 import Message exposing (Msg)
 import Page.Data
 import Shared exposing (Model)
-import Theme.Global exposing (centerContent, primaryHeader, roundedCornerStyle, withMediaTabletLandscapeUp)
+import Theme.Global exposing (centerContent, primaryHeader, roundedCornerStyle, simpleThreeColumnFlexChildStyle, simpleThreeColumnFlexStyle, withMediaTabletLandscapeUp)
 import Theme.Markdown exposing (markdownToHtml)
 
 
@@ -24,7 +24,7 @@ viewSubmitFlex : Model -> Page.Data.Page -> Html Msg
 viewSubmitFlex model page =
     div
         [ css
-            [ submitFlexStyle ]
+            [ simpleThreeColumnFlexStyle, outerMarginStyle ]
         ]
         [ viewDescription page
         , viewForm model
@@ -34,7 +34,7 @@ viewSubmitFlex model page =
 
 viewDescription : Page.Data.Page -> Html Msg
 viewDescription page =
-    div [ css [ flexChildStyle ] ]
+    div [ css [ simpleThreeColumnFlexChildStyle ] ]
         (markdownToHtml page.fullTextMarkdown)
 
 
@@ -45,7 +45,7 @@ viewForm model =
         t =
             translate model.language
     in
-    div [ css [ batch [ width (pct 100) ], flexChildStyle ] ]
+    div [ css [ batch [ width (pct 100) ], simpleThreeColumnFlexChildStyle ] ]
         [ h2 [] [ text (t SubmitFormHeading) ]
         , iframe
             [ Attr.src (t SubmitFormSrc)
@@ -85,31 +85,18 @@ submitImgGridStyle =
         ]
 
 
-submitFlexStyle : Style
-submitFlexStyle =
+outerMarginStyle : Style
+outerMarginStyle =
     batch
-        [ displayFlex
-        , property "gap" "3rem"
-        , flexWrap wrap
-        , margin (rem 0)
-        , withMediaTabletLandscapeUp
+        [ withMediaTabletLandscapeUp
             [ margin2 (rem 3) (rem 0)
             ]
         ]
 
 
-flexChildStyle : Style
-flexChildStyle =
-    batch
-        [ flexShrink (int 1)
-        , flexGrow (int 1)
-        , property "flex-basis" "25rem"
-        ]
-
-
 viewImageGrid : List ( String, String ) -> Html Msg
 viewImageGrid images =
-    div [ css [ submitImgGridStyle, flexChildStyle ] ]
+    div [ css [ submitImgGridStyle, simpleThreeColumnFlexChildStyle ] ]
         (List.map (\( src, alt ) -> viewGridItem src alt) images)
 
 

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,6 +1,6 @@
-module Theme.Global exposing (borderWrapper, centerContent, contentWrapper, featureImageStyle, globalStyles, hideFromPrint, lightPurple, lightTeal, listStyleNone, maxTabletPortrait, mediumTeal, pageColumnStyle, primaryHeader, purple, roundedCornerStyle, screenReaderOnly, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, topTwoColumnsWrapperStyle, white, withMediaDesktopUp, withMediaMobileUp, withMediaPrint, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+module Theme.Global exposing (borderWrapper, centerContent, contentWrapper, featureImageStyle, globalStyles, hideFromPrint, lightPurple, lightTeal, listStyleNone, maxTabletPortrait, mediumTeal, pageColumnStyle, primaryHeader, purple, roundedCornerStyle, screenReaderOnly, simpleThreeColumnFlexChildStyle, simpleThreeColumnFlexStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, topTwoColumnsWrapperStyle, white, withMediaDesktopUp, withMediaMobileUp, withMediaPrint, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 
-import Css exposing (Color, Style, absolute, alignItems, auto, backgroundColor, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, border, border3, borderBottomRightRadius, borderRadius4, borderTopLeftRadius, borderTopRightRadius, boxSizing, breakWord, center, cm, color, column, contentBox, cover, cursor, display, displayFlex, flex, flex3, flexDirection, flexStart, flexWrap, fontFamilies, height, hex, hidden, hover, inherit, int, justifyContent, lastChild, left, listStyle, margin, margin2, margin3, marginBottom, marginRight, maxWidth, minWidth, noRepeat, noWrap, none, overflow, overflowWrap, padding, padding2, paddingLeft, pct, pointer, position, property, pseudoElement, px, rem, row, solid, textDecoration, textDecoration3, top, underline, width, zero)
+import Css exposing (Color, Style, absolute, alignItems, auto, backgroundColor, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, border, border3, borderBottomRightRadius, borderRadius4, borderTopLeftRadius, borderTopRightRadius, boxSizing, breakWord, center, cm, color, column, contentBox, cover, cursor, display, displayFlex, flex, flex3, flexDirection, flexGrow, flexShrink, flexStart, flexWrap, fontFamilies, height, hex, hidden, hover, inherit, int, justifyContent, lastChild, left, listStyle, margin, margin2, margin3, marginBottom, marginRight, maxWidth, minWidth, noRepeat, noWrap, none, overflow, overflowWrap, padding, padding2, paddingLeft, pct, pointer, position, property, pseudoElement, px, rem, row, solid, textDecoration, textDecoration3, top, underline, width, wrap, zero)
 import Css.Global exposing (global, typeSelector)
 import Css.Media as Media exposing (only, print, screen, withMedia)
 import Html.Styled exposing (Html, h1, text)
@@ -408,4 +408,23 @@ borderWrapper : Style
 borderWrapper =
     batch
         [ border3 (rem 0.5) solid teal
+        ]
+
+
+simpleThreeColumnFlexStyle : Style
+simpleThreeColumnFlexStyle =
+    batch
+        [ displayFlex
+        , property "gap" "3rem"
+        , flexWrap wrap
+        , margin (rem 0)
+        ]
+
+
+simpleThreeColumnFlexChildStyle : Style
+simpleThreeColumnFlexChildStyle =
+    batch
+        [ flexShrink (int 1)
+        , flexGrow (int 1)
+        , property "flex-basis" "25rem"
         ]


### PR DESCRIPTION
Fixes #504 

## Description

- Renames and moves submit story containers into global as simple flex column containers so that I can reuse them for the header (I also did this because the styling @aaaaargZombies devised for this is much simpler than the system I had previously devised to use flex containers without using gaps, if we come back to this again this is a much better base for this three column layout and it made more sense as a generic container)
- Increases the submit your story text size
- tweaks margins and gaps for the header specific scenario


@geeksforsocialchange/developers
