### PR TITLE
Shrink badger and rejig layout slightly to more closely match other ancillary pages

### DIFF
--- a/src/Page/NotFound.elm
+++ b/src/Page/NotFound.elm
@@ -1,6 +1,6 @@
 module Page.NotFound exposing (resourceNotFound)
 
-import Css exposing (Style, alignItems, batch, center, column, display, displayFlex, flexDirection, justifyContent, marginBottom, maxWidth, pct, rem, row, spaceBetween, width)
+import Css exposing (Style, alignItems, batch, center, column, display, displayFlex, flexDirection, flexStart, justifyContent, marginBottom, maxWidth, pct, rem, row, spaceBetween, width)
 import Html.Styled exposing (Html, a, div, img, p, text)
 import Html.Styled.Attributes exposing (css, href, src)
 import I18n.Keys exposing (Key(..))
@@ -33,7 +33,7 @@ badgerImageStyle : Style
 badgerImageStyle =
     batch
         [ maxWidth (rem 20)
-        , marginBottom (rem 2)
+        , marginBottom (rem 1)
         ]
 
 
@@ -45,7 +45,8 @@ simpleTwoColumnsFlexStyle =
         , flexDirection column
         , width (pct 100)
         , withMediaMobileUp
-            [ flexDirection row
+            [ alignItems flexStart
+            , flexDirection row
             , justifyContent spaceBetween
             ]
         ]

--- a/src/Page/NotFound.elm
+++ b/src/Page/NotFound.elm
@@ -1,11 +1,11 @@
 module Page.NotFound exposing (resourceNotFound)
 
-import Css exposing (Style, batch, pct, width)
+import Css exposing (Style, alignItems, batch, center, column, display, displayFlex, flexDirection, justifyContent, marginBottom, maxWidth, pct, rem, row, spaceBetween, width)
 import Html.Styled exposing (Html, a, div, img, p, text)
 import Html.Styled.Attributes exposing (css, href, src)
 import I18n.Keys exposing (Key(..))
 import I18n.Translate exposing (Language, translate)
-import Theme.Global exposing (centerContent, contentWrapper, pageColumnStyle, primaryHeader, topTwoColumnsWrapperStyle)
+import Theme.Global exposing (centerContent, contentWrapper, pageColumnStyle, primaryHeader, simplePageContentContainerStyle, topTwoColumnsWrapperStyle, withMediaMobileUp, withMediaTabletPortraitUp)
 
 
 resourceNotFound : Language -> Html msg
@@ -15,23 +15,37 @@ resourceNotFound language =
         t =
             translate language
     in
-    div [ css [ centerContent ] ]
-        [ div [ css [ contentWrapper, width (pct 100) ] ]
-            [ div [ css [ topTwoColumnsWrapperStyle ] ]
-                [ div [ css [ pageColumnStyle ] ]
-                    [ primaryHeader [] (t ResourceNotFoundTitle)
-                    , div []
-                        [ p [] [ text (t ResourceNotFoundText) ]
-                        , a [ href (t ResourceNotFoundLinkPath) ] [ text (t ResourceNotFoundLinkText) ]
-                        ]
+    div [ css [ centerContent, simplePageContentContainerStyle ] ]
+        [ div [ css [ simpleTwoColumnsFlexStyle ] ]
+            [ div [ css [ pageColumnStyle ] ]
+                [ primaryHeader [] (t ResourceNotFoundTitle)
+                , div []
+                    [ p [] [ text (t ResourceNotFoundText) ]
+                    , a [ href (t ResourceNotFoundLinkPath) ] [ text (t ResourceNotFoundLinkText) ]
                     ]
-                , div [ css [ pageColumnStyle ] ]
-                    [ img [ src "/images/badger-question.png", css [ badgeImageStyle ] ] [] ]
                 ]
+            , img [ src "/images/badger-question.png", css [ badgerImageStyle ] ] []
             ]
         ]
 
 
-badgeImageStyle : Style
-badgeImageStyle =
-    batch []
+badgerImageStyle : Style
+badgerImageStyle =
+    batch
+        [ maxWidth (rem 20)
+        , marginBottom (rem 2)
+        ]
+
+
+simpleTwoColumnsFlexStyle : Style
+simpleTwoColumnsFlexStyle =
+    batch
+        [ alignItems center
+        , displayFlex
+        , flexDirection column
+        , width (pct 100)
+        , withMediaMobileUp
+            [ flexDirection row
+            , justifyContent spaceBetween
+            ]
+        ]

--- a/src/Page/View.elm
+++ b/src/Page/View.elm
@@ -1,26 +1,16 @@
 module Page.View exposing (view)
 
-import Css exposing (Style, batch, maxWidth, minHeight, px)
 import Html.Styled exposing (Html, div)
 import Html.Styled.Attributes exposing (css)
 import Message exposing (Msg)
 import Page.Data
-import Theme.Global exposing (centerContent, maxTabletPortrait, primaryHeader)
+import Theme.Global exposing (centerContent, primaryHeader, simplePageContentContainerStyle)
 import Theme.Markdown exposing (markdownToHtml)
 
 
 view : Page.Data.Page -> Html Msg
 view page =
-    div [ css [ centerContent, ancillaryPageTextContainerStyle ] ]
+    div [ css [ centerContent, simplePageContentContainerStyle ] ]
         [ primaryHeader [] page.title
         , div [] (markdownToHtml page.fullTextMarkdown)
-        ]
-
-
-ancillaryPageTextContainerStyle : Style
-ancillaryPageTextContainerStyle =
-    batch
-        [ maxWidth (px maxTabletPortrait)
-        , minHeight
-            (px 300)
         ]

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,6 +1,6 @@
-module Theme.Global exposing (borderWrapper, centerContent, contentWrapper, featureImageStyle, globalStyles, hideFromPrint, lightPurple, lightTeal, listStyleNone, maxTabletPortrait, mediumTeal, pageColumnStyle, primaryHeader, purple, roundedCornerStyle, screenReaderOnly, simpleThreeColumnFlexChildStyle, simpleThreeColumnFlexStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, topTwoColumnsWrapperStyle, white, withMediaDesktopUp, withMediaMobileUp, withMediaPrint, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+module Theme.Global exposing (borderWrapper, centerContent, contentWrapper, featureImageStyle, globalStyles, hideFromPrint, lightPurple, lightTeal, listStyleNone, maxTabletPortrait, mediumTeal, pageColumnStyle, primaryHeader, purple, roundedCornerStyle, screenReaderOnly, simplePageContentContainerStyle, simpleThreeColumnFlexChildStyle, simpleThreeColumnFlexStyle, teal, teaserContainerStyle, teaserImageStyle, teaserRowStyle, topTwoColumnsWrapperStyle, white, withMediaDesktopUp, withMediaMobileUp, withMediaPrint, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 
-import Css exposing (Color, Style, absolute, alignItems, auto, backgroundColor, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, border, border3, borderBottomRightRadius, borderRadius4, borderTopLeftRadius, borderTopRightRadius, boxSizing, breakWord, center, cm, color, column, contentBox, cover, cursor, display, displayFlex, flex, flex3, flexDirection, flexGrow, flexShrink, flexStart, flexWrap, fontFamilies, height, hex, hidden, hover, inherit, int, justifyContent, lastChild, left, listStyle, margin, margin2, margin3, marginBottom, marginRight, maxWidth, minWidth, noRepeat, noWrap, none, overflow, overflowWrap, padding, padding2, paddingLeft, pct, pointer, position, property, pseudoElement, px, rem, row, solid, textDecoration, textDecoration3, top, underline, width, wrap, zero)
+import Css exposing (Color, Style, absolute, alignItems, auto, backgroundColor, backgroundImage, backgroundPosition, backgroundRepeat, backgroundSize, batch, border, border3, borderBottomRightRadius, borderRadius4, borderTopLeftRadius, borderTopRightRadius, boxSizing, breakWord, center, cm, color, column, contentBox, cover, cursor, display, displayFlex, flex, flex3, flexDirection, flexGrow, flexShrink, flexStart, flexWrap, fontFamilies, height, hex, hidden, hover, inherit, int, justifyContent, lastChild, left, listStyle, margin, margin2, margin3, marginBottom, marginRight, maxWidth, minHeight, minWidth, noRepeat, noWrap, none, overflow, overflowWrap, padding, padding2, paddingLeft, pct, pointer, position, property, pseudoElement, px, rem, row, solid, textDecoration, textDecoration3, top, underline, width, wrap, zero)
 import Css.Global exposing (global, typeSelector)
 import Css.Media as Media exposing (only, print, screen, withMedia)
 import Html.Styled exposing (Html, h1, text)
@@ -427,4 +427,13 @@ simpleThreeColumnFlexChildStyle =
         [ flexShrink (int 1)
         , flexGrow (int 1)
         , property "flex-basis" "25rem"
+        ]
+
+
+simplePageContentContainerStyle : Style
+simplePageContentContainerStyle =
+    batch
+        [ maxWidth (px maxTabletPortrait)
+        , minHeight
+            (px 300)
         ]


### PR DESCRIPTION
Fixes #253

## Description

- shrinks badger so footer comes back into view
- changes layout method slightly to simplify it and better match the other ancillary pages & restricts content to central 900px of page

@geeksforsocialchange/developers
