### PR TITLE
Allow longer summaries in guides but only print full summary in header

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -103,7 +103,7 @@ collections:
           label: "Summary",
           name: "summary",
           widget: "string",
-          pattern: ["^.{50,160}$", "Must be between 50 and 160 characters"],
+          pattern: ["^.{50,480}$", "Must be between 50 and 480 characters"],
           i18n: true,
         }
       - {

--- a/src/Metadata.elm
+++ b/src/Metadata.elm
@@ -98,12 +98,20 @@ guideMetadataFromSlug slug contentDict =
         Just content ->
             Just
                 { title = content.title
-                , description = content.summary
+                , description = shortDescriptionFromSummary content.summary
                 , imageSrc = imageSrcFromMaybeImage content.maybeImage
                 }
 
         Nothing ->
             Nothing
+
+
+shortDescriptionFromSummary : String -> String
+shortDescriptionFromSummary summary =
+    (List.head (String.split "." summary)
+        |> Maybe.withDefault summary
+    )
+        ++ "."
 
 
 storyMetadataFromSlug :

--- a/src/Page/Search/View.elm
+++ b/src/Page/Search/View.elm
@@ -61,7 +61,7 @@ viewGuideTeaserSummary summary =
     if String.length summary > 0 then
         p
             [ css [ Theme.Global.teaserRowStyle ] ]
-            [ text <| limitContent summary 240 ]
+            [ text (limitContent summary) ]
 
     else
         text ""
@@ -101,15 +101,13 @@ viewTeaserList language searchString teasers =
         text ""
 
 
-limitContent : String -> Int -> String
-limitContent summary limit =
-    if String.length summary > limit then
-        summary
-            |> String.slice 0 (limit - 3)
-            |> String.padRight limit '.'
-
-    else
-        summary
+limitContent : String -> String
+limitContent summary =
+    -- Grab the first (or only sentence) and add a fullstop
+    (List.head (String.split "." summary)
+        |> Maybe.withDefault summary
+    )
+        ++ "."
 
 
 guidesPageLayoutStyle : Style


### PR DESCRIPTION
Fixes #538

## Description

- Allow summary to be longer on guide page
- Only use first sentence for meta description & teaser

@geeksforsocialchange/developers
