### PR TITLE
Change appearance of action and story teasers

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -69,11 +69,10 @@ collections:
             }
       - {
           label: "Summary",
-          hint: "Only used for SEO description",
+          hint: "Used for SEO description and teaser links",
           name: "summary",
           widget: "string",
           pattern: ["^.{50,160}$", "Must be between 50 and 160 characters"],
-          required: false,
           i18n: true,
         }
       - {

--- a/src/Page/Search/Data.elm
+++ b/src/Page/Search/Data.elm
@@ -106,7 +106,7 @@ teaserListFromStoryDict language stories =
             (\s ->
                 { title = s.title
                 , url = Route.toString (Route.Story s.slug)
-                , summary = ""
+                , summary = s.summary
                 , maybeImage = storyImagefromTeaserImage s.images
                 }
             )

--- a/src/Page/Search/View.elm
+++ b/src/Page/Search/View.elm
@@ -1,6 +1,6 @@
 module Page.Search.View exposing (view)
 
-import Css exposing (Style, batch, fontWeight, int, margin, marginBottom, padding, pct, property, rem, width)
+import Css exposing (Style, batch, fontWeight, int, margin, margin3, marginBottom, padding, pct, property, rem, width)
 import Html.Styled exposing (Html, a, div, h2, h3, img, li, p, section, text, ul)
 import Html.Styled.Attributes exposing (alt, attribute, css, href, id, src)
 import I18n.Keys exposing (Key(..))
@@ -73,7 +73,7 @@ viewGuideStoryActionLists model =
     List.map (\viewList -> viewList)
         [ viewTeaserList ( "guides", GuidesHeading, teaserData.guides ) model.language model.query
         , viewTeaserList ( "stories", StoriesHeading, teaserData.stories ) model.language model.query
-        , viewTeaserList ( "actions", ActionsHeading, teaserData.actions ) model.language model.query
+        , viewActionsList ( "actions", ActionsHeading, teaserData.actions ) model.language model.query
         ]
 
 
@@ -84,18 +84,10 @@ viewTeaserList ( sectionId, sectionName, teasers ) language searchString =
             t : Key -> String
             t =
                 translate language
-
-            sectionHeader : String
-            sectionHeader =
-                if String.length searchString > 0 then
-                    t (SearchTitleFiltered (List.length teasers) searchString)
-
-                else
-                    ""
         in
         section [ css [ marginBottom (rem 4) ] ]
             [ h2 [ id sectionId ] [ text (t sectionName) ]
-            , h3 [] [ text sectionHeader ]
+            , h3 [] [ text (viewSectionHeader searchString t teasers) ]
             , ul [ css [ guidesPageLayoutStyle ] ]
                 (teasers
                     |> List.map
@@ -105,6 +97,40 @@ viewTeaserList ( sectionId, sectionName, teasers ) language searchString =
 
     else
         text ""
+
+
+viewActionsList : ( String, Key, List Page.Shared.Data.Teaser ) -> Language -> String -> Html Msg
+viewActionsList ( sectionId, sectionName, teasers ) language searchString =
+    if List.length teasers > 0 then
+        let
+            t : Key -> String
+            t =
+                translate language
+        in
+        section [ css [ marginBottom (rem 4) ] ]
+            [ h2 [ id sectionId ] [ text (t sectionName) ]
+            , h3 [] [ text (viewSectionHeader searchString t teasers) ]
+            , ul [ css [ actionTeasersPageLayoutStyle ] ]
+                (teasers
+                    |> List.map
+                        (\teaser ->
+                            p []
+                                [ a [ css [ fontWeight (int 600) ], href teaser.url ] [ text teaser.title ] ]
+                        )
+                )
+            ]
+
+    else
+        text ""
+
+
+viewSectionHeader : String -> (Key -> String) -> List Page.Shared.Data.Teaser -> String
+viewSectionHeader searchString t teasers =
+    if String.length searchString > 0 then
+        t (SearchTitleFiltered (List.length teasers) searchString)
+
+    else
+        ""
 
 
 limitContent : String -> String
@@ -138,6 +164,23 @@ guidesPageLayoutStyle =
             ]
         , withMediaMobileUp
             [ property "grid-template-columns" "repeat(3, 1fr)"
+            ]
+        ]
+
+
+actionTeasersPageLayoutStyle : Style
+actionTeasersPageLayoutStyle =
+    batch
+        [ margin3 (rem 2) (rem 0) (rem 0)
+        , padding (rem 0)
+        , width (pct 100)
+        , withMediaTabletLandscapeUp
+            [ property "grid-template-columns" "repeat(3, 1fr)"
+            ]
+        , withMediaMobileUp
+            [ property "display" "grid"
+            , property "gap" "0rem 2rem"
+            , property "grid-template-columns" "repeat(2, 1fr)"
             ]
         ]
 

--- a/src/Page/Search/View.elm
+++ b/src/Page/Search/View.elm
@@ -1,6 +1,7 @@
 module Page.Search.View exposing (view)
 
 import Css exposing (Style, batch, fontWeight, int, margin, margin3, marginBottom, padding, pct, property, rem, width)
+import Css.Transitions exposing (columnCount)
 import Html.Styled exposing (Html, a, div, h2, h3, img, li, p, section, text, ul)
 import Html.Styled.Attributes exposing (alt, attribute, css, href, id, src)
 import I18n.Keys exposing (Key(..))
@@ -10,7 +11,7 @@ import Message exposing (Msg)
 import Page.Search.Data
 import Page.Shared.Data
 import Shared exposing (Model)
-import Theme.Global exposing (centerContent, primaryHeader, withMediaDesktopUp, withMediaMobileUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Theme.Global exposing (centerContent, listStyleNone, primaryHeader, withMediaDesktopUp, withMediaMobileUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 
 
 view : Model -> Html Msg
@@ -114,8 +115,9 @@ viewActionsList ( sectionId, sectionName, teasers ) language searchString =
                 (teasers
                     |> List.map
                         (\teaser ->
-                            p []
-                                [ a [ css [ fontWeight (int 600) ], href teaser.url ] [ text teaser.title ] ]
+                            li [ css [ listStyleNone ] ]
+                                [ a [ href teaser.url ] [ text teaser.title ]
+                                ]
                         )
                 )
             ]
@@ -175,12 +177,11 @@ actionTeasersPageLayoutStyle =
         , padding (rem 0)
         , width (pct 100)
         , withMediaTabletLandscapeUp
-            [ property "grid-template-columns" "repeat(3, 1fr)"
+            [ property "column-count" "3"
             ]
         , withMediaMobileUp
-            [ property "display" "grid"
-            , property "gap" "0rem 2rem"
-            , property "grid-template-columns" "repeat(2, 1fr)"
+            [ property "column-count" "2"
+            , property "column-gap" "2rem"
             ]
         ]
 

--- a/src/Page/Story/Data.elm
+++ b/src/Page/Story/Data.elm
@@ -41,6 +41,7 @@ defaultStoryImageSrc =
 type alias StoryTeaser =
     { titleKey : String
     , slug : String
+    , summary : String
     , en : { title : String, maybeImage : Maybe Image }
     , cy : { title : String, maybeImage : Maybe Image }
     }
@@ -126,6 +127,7 @@ allStoryTeaserList stories =
             (\( _, story ) ->
                 { slug = story.slug
                 , titleKey = story.title
+                , summary = story.summary
                 , en = translationsFromSlug stories.en story
                 , cy = translationsFromSlug stories.cy story
                 }

--- a/tests/Guide.elm
+++ b/tests/Guide.elm
@@ -83,6 +83,7 @@ suite =
         allStoryList =
             [ { titleKey = "A related story"
               , slug = "a-related-story"
+              , summary = "test summary"
               , cy =
                     { title = ""
                     , maybeImage = Nothing
@@ -94,6 +95,7 @@ suite =
               }
             , { titleKey = "Another related story"
               , slug = "another-story"
+              , summary = "test summary"
               , cy =
                     { title = ""
                     , maybeImage = Nothing


### PR DESCRIPTION
Fixes #542 

## Description

- Adds a summary to story teasers, and makes this field compulsory in the CMS - have checked and all stories currently have this, have also updated UAT docs
- Removes summary and image from action teasers and restyles this section as a three column list, matching styling used for topics list on homepage and 3 column layout used elsewhere on the site

@geeksforsocialchange/developers
