### PR TITLE
Show 0 results returned when search returns no results

### DIFF
--- a/src/I18n/Cy.elm
+++ b/src/I18n/Cy.elm
@@ -181,11 +181,11 @@ cyStrings key =
             "[cCc] Search page description in Welsh"
 
         SearchTitleFiltered count query ->
-            if count > 1 then
-                String.join " " [ String.fromInt count, "canllawiau ar", query ]
+            if count == 1 then
+                String.join " " [ "1 canllaw ar", query ]
 
             else
-                String.join " " [ "1 canllaw ar", query ]
+                String.join " " [ String.fromInt count, "canllawiau ar", query ]
 
         GuidesHeading ->
             "[cCc]"

--- a/src/I18n/En.elm
+++ b/src/I18n/En.elm
@@ -183,11 +183,11 @@ enStrings key =
             "Take action for nature"
 
         SearchTitleFiltered count query ->
-            if count > 1 then
-                String.join " " [ String.fromInt count, "results for", query ]
+            if count == 1 then
+                String.join " " [ "1 result for", query ]
 
             else
-                String.join " " [ "1 result for", query ]
+                String.join " " [ String.fromInt count, "results for", query ]
 
         SearchPlaceholder ->
             "Search this hub"

--- a/src/Page/Search/Data.elm
+++ b/src/Page/Search/Data.elm
@@ -114,17 +114,7 @@ teasersFromSearchableType itemType teasers =
 
 getTeaserListsFromSearch : Shared.Model -> Shared.SearchData
 getTeaserListsFromSearch model =
-    let
-        hasResults : Bool
-        hasResults =
-            List.length model.searchResult.actions
-                > 0
-                || List.length model.searchResult.guides
-                > 0
-                || List.length model.searchResult.stories
-                > 0
-    in
-    if String.length model.query > 0 && hasResults then
+    if String.length model.query > 0 then
         let
             actionResults : List Page.Shared.Data.Teaser
             actionResults =

--- a/src/Page/Search/View.elm
+++ b/src/Page/Search/View.elm
@@ -22,7 +22,7 @@ view model =
     in
     div [ css [ centerContent ] ]
         [ primaryHeader [ attribute "aria-live" "alert", css [ guidesSearchTitleStyle ] ] (t SearchTitle)
-        , div [] (viewGuideStoryActionLists model)
+        , div [ css [ width (pct 100) ] ] (viewGuideStoryActionLists model)
         ]
 
 
@@ -74,6 +74,7 @@ viewGuideStoryActionLists model =
     [ viewTeaserList ( "guides", GuidesHeading, teaserData.guides ) model.language model.query
     , viewTeaserList ( "stories", StoriesHeading, teaserData.stories ) model.language model.query
     , viewActionsList ( "actions", ActionsHeading, teaserData.actions ) model.language model.query
+    , viewNoResults teaserData model.language model.query
     ]
 
 
@@ -93,6 +94,31 @@ viewTeaserList ( sectionId, sectionName, teasers ) language searchString =
                     |> List.map
                         (\teaser -> viewGuideTeaser teaser)
                 )
+            ]
+
+    else
+        text ""
+
+
+viewNoResults : Shared.SearchData -> Language -> String -> Html Msg
+viewNoResults teasers language searchString =
+    if
+        String.length searchString
+            > 0
+            && List.length teasers.guides
+            == 0
+            && List.length teasers.actions
+            == 0
+            && List.length teasers.stories
+            == 0
+    then
+        let
+            t : Key -> String
+            t =
+                translate language
+        in
+        section [ css [ marginBottom (rem 4) ] ]
+            [ h2 [] [ text (viewSectionHeader searchString t teasers.guides) ]
             ]
 
     else

--- a/src/Page/Search/View.elm
+++ b/src/Page/Search/View.elm
@@ -118,7 +118,7 @@ viewNoResults teasers language searchString =
                 translate language
         in
         section [ css [ marginBottom (rem 4) ] ]
-            [ h2 [] [ text (viewSectionHeader searchString t teasers.guides) ]
+            [ h2 [] [ text (t (SearchTitleFiltered 0 searchString)) ]
             ]
 
     else


### PR DESCRIPTION
Fixes #556

## Description

- Adds a view that will only display if no results returned and search query > 0, which uses an h2 header to announce 0 results returned
- Makes section outer 100% width so that when actions or stories are returned they don't shrink or centre themselves

@geeksforsocialchange/developers
