### PR TITLE
fix: Reduce site title line-height to 1

### DIFF
--- a/src/Theme/HeaderTemplate.elm
+++ b/src/Theme/HeaderTemplate.elm
@@ -97,7 +97,7 @@ headerBrandStyle =
         , color white
         , fontFamilies [ "Ludicrous" ]
         , fontWeight normal
-        , lineHeight (em 1.2)
+        , lineHeight (em 1)
         , margin zero
         , withMediaMobileUp
             [ marginRight (rem 3) ]


### PR DESCRIPTION
Fixes #451

## Description

- Reduce line height to 1 em in h1 header

This was easiest path for fix. If we end up getting a logo, we can raise an issue to replace.

@geeksforsocialchange/developers
